### PR TITLE
MoviesCount HOC pollInterval fix

### DIFF
--- a/packages/getting-started/lib/hocs/withMoviesCount.js
+++ b/packages/getting-started/lib/hocs/withMoviesCount.js
@@ -3,15 +3,15 @@ import { graphql } from 'react-apollo';
 import gql from 'graphql-tag';
 
 const withMoviesCount = component => {
-  
+
   return graphql(gql`
     query MoviesCount{
       MoviesCount
-    } 
+    }
     `, {
       alias: 'withMoviesCount',
       options: {
-        pollInterval: 5
+        pollInterval: 1000
       },
       props(props) {
         return {


### PR DESCRIPTION
The pollInterval was set to 5ms, set it to 1000 instead, to limit the amount of graphql queries.
Originally found by @mathiaskandelborg