### PR TITLE
Add example 'contact us' package

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint --cache --ext .jsx,js packages"
   },
   "dependencies": {
-    "@babel/runtime": "^7.0.0-beta.38",
+    "@babel/runtime": "^7.0.0-beta.42",
     "analytics-node": "^2.1.1",
     "apollo-client": "^1.2.2",
     "apollo-engine": "^0.5.4",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "react-syntax-highlighter": "^6.1.2",
     "recompose": "^0.26.0",
     "redux": "^3.6.0",
+    "regular-expression-validation": "^1.0.1",
     "rss": "^1.2.1",
     "sanitize-html": "^1.16.3",
     "sendy-api": "^0.1.0",

--- a/packages/example-contact-us/lib/client/main.js
+++ b/packages/example-contact-us/lib/client/main.js
@@ -1,0 +1,1 @@
+import '../modules/index.js';

--- a/packages/example-contact-us/lib/components/Home.js
+++ b/packages/example-contact-us/lib/components/Home.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Components, withList, registerComponent } from 'meteor/vulcan:core';
-
 import ContactUsForm from '../modules/contact-us/collection.js';
+
 
 const ContactUs = ({
   results = [],
@@ -25,6 +25,7 @@ const ContactUs = ({
       <Components.Loading />
     ) : (
       <div>
+
         {results.map(userSubmission => (
           <Components.Card
             key={userSubmission._id}

--- a/packages/example-contact-us/lib/components/Home.js
+++ b/packages/example-contact-us/lib/components/Home.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import { Components, withList, registerComponent } from 'meteor/vulcan:core';
+
+import ContactUsForm from '../modules/contact-us/collection.js';
+
+const ContactUs = ({
+  results = [],
+  currentUser,
+  loading,
+  loadMore,
+  count,
+  totalCount,
+}) => (
+  <div style={{ maxWidth: '500px', margin: '20px auto' }}>
+    <h1>Get in contact</h1>
+
+    {/*
+      * Load the 'contact us' SmartForm no matter what and
+      * display the latest submissions beneath the form
+      *
+      */}
+    <Components.SmartForm collection={ContactUsForm} />
+
+    {loading ? (
+      <Components.Loading />
+    ) : (
+      <div>
+        {results.map(userSubmission => (
+          <Components.Card
+            key={userSubmission._id}
+            collection={ContactUsForm}
+            document={userSubmission}
+            currentUser={currentUser}
+          />
+        ))}
+
+        {totalCount > results.length ? (
+          <a
+            href="#"
+            onClick={e => {
+              e.preventDefault();
+              loadMore();
+            }}
+          >
+            Load More ({count}/{totalCount})
+          </a>
+        ) : (
+          <p>No more items.</p>
+        )}
+      </div>
+    )}
+  </div>
+);
+
+const options = {
+  collection: ContactUsForm,
+  limit: 10,
+};
+
+registerComponent('ContactUs', ContactUs, [withList, options]);

--- a/packages/example-contact-us/lib/components/Home.js
+++ b/packages/example-contact-us/lib/components/Home.js
@@ -11,16 +11,41 @@ const ContactUs = ({
   count,
   totalCount,
 }) => (
-  <div style={{ maxWidth: '500px', margin: '20px auto' }}>
-    <h1>Get in contact</h1>
+  <div style={{ maxWidth: '980px', width: '95vw', margin: '20px auto', fontFamily: 'Verdana, Geneva, sans-serif'}}>
+    <h1 style={{ textAlign: 'center'}} >CONTACT US FORM - EXAMPLE PACKAGE</h1>
+    <hr/>
+    <h3>This package shows how you easily can implement a 'contact us' form in your app.</h3>
+    <br/>
 
+    <h3>Configuring email addresses</h3>
+    <p>In <code>sample_settings.json</code>, you can edit the defaultEmail setting.</p>
+    <p>The "defaultEmail" setting is used as the address to <i>send</i> emails from.</p>
+    <p>When the submit button is pressed, Vulcan sends two emails: one to the address from the 'Your email' input and one to the 'site admin'.</p>
+    <p>This makes it easy to organise and answer to submissions with your email client.</p>
+    <p>The 'site admin' email can be changed by editing the string inside <code>/lib/server/callbacks/contactUsEmail.js</code> on line 24.</p>
+    <p>If you want to configure how the email subject is formatted, you can edit it in the email package in the email.js file.</p>
+    <p>To add a name when sending and receiving emails, write the name followed by the email wrapped in '&lt;' and '&gt;':</p>
+    <p><code>"My Name &lt;site-admin@email.com&gt;"</code></p>
+    <br/>
+
+    <h3>Sending real emails</h3>
+    <i>This section is made for Mailgun but should be generally applicable. It doesn't go into details on how to register a custom domain. Before you send real emails, please make sure you have an SMTP server or a service like Mailgun ready.</i>
+    <br/>
+    <p>In <code>sample_settings.json</code>, you have to edit the "mailUrl" setting to fit your credentials.</p>
+    <p>That last part ':587' is the port and stays unchanged unless you know it has to be changed.</p>
+    <p>To enable emails in development mode, you need to create and set the "developmentEmails" option to true in <code>sample_settings.json</code></p>
+    <p>If you want to use your own domain with Mailgun:</p>
+    <p>Sign up and get automatic validation my registering a card with them. This is to avoid spam bots etc.</p>
+    <p>Register your custom domain by following the instruction, e.g. setting the respective TXT and MX records on the same server your domain's A record is.</p>
+    <p>Please note that DNS propagation takes some time. Lowering TTL on records can speed things up but is a bad practice if you don't change them back once you've got things working.</p>
+    <hr/>
     {/*
       * Load the 'contact us' SmartForm no matter what and
       * display the latest submissions beneath the form
       *
       */}
+    <h2>Get in contact</h2>
     <Components.SmartForm collection={ContactUsForm} />
-
     {loading ? (
       <Components.Loading />
     ) : (

--- a/packages/example-contact-us/lib/components/forms/contact-us/ContactUsNewForm.jsx
+++ b/packages/example-contact-us/lib/components/forms/contact-us/ContactUsNewForm.jsx
@@ -1,0 +1,9 @@
+import React, { PropTypes, Component } from 'react';
+import { Components, registerComponent, getFragment } from 'meteor/vulcan:core';
+import ContactUsForm from '../../../modules/contact-us/collection.js';
+
+const ContactUs = () => (
+  <Components.SmartForm collection={ContactUsForm} mutationFragment={getFragment('ContactUsFragment')} />
+);
+
+registerComponent('ContactUsForm', ContactUs);

--- a/packages/example-contact-us/lib/modules/contact-us/collection.js
+++ b/packages/example-contact-us/lib/modules/contact-us/collection.js
@@ -1,0 +1,23 @@
+import {
+  createCollection,
+  getDefaultResolvers,
+  getDefaultMutations,
+} from 'meteor/vulcan:core';
+
+import schema from './schema.js';
+import './fragments.js';
+import './permissions.js';
+
+const ContactUsForm = createCollection({
+  schema,
+  collectionName: 'ContactUsForm',
+  typeName: 'ContactUsForm',
+  resolvers: getDefaultResolvers('ContactUsForm'),
+  mutations: getDefaultMutations('ContactUsForm', {
+    newCheck: (user, document) => {
+      return document;
+    },
+  }),
+});
+
+export default ContactUsForm;

--- a/packages/example-contact-us/lib/modules/contact-us/fragments.js
+++ b/packages/example-contact-us/lib/modules/contact-us/fragments.js
@@ -1,0 +1,11 @@
+import { registerFragment } from 'meteor/vulcan:core';
+
+registerFragment(`
+  fragment ContactUsFragment on ContactUsForm {
+    _id
+    createdAt
+    userName
+    sendToEmail
+    emailContent
+  }
+`);

--- a/packages/example-contact-us/lib/modules/contact-us/permissions.js
+++ b/packages/example-contact-us/lib/modules/contact-us/permissions.js
@@ -1,0 +1,3 @@
+import Users from 'meteor/vulcan:users';
+
+Users.groups.guests.can(['ContactUsForm.new']);

--- a/packages/example-contact-us/lib/modules/contact-us/schema.js
+++ b/packages/example-contact-us/lib/modules/contact-us/schema.js
@@ -1,0 +1,45 @@
+import { Components } from 'meteor/vulcan:core';
+
+const schema = {
+  _id: {
+    type: String,
+    optional: true,
+    viewableBy: ['guests'],
+  },
+  createdAt: {
+    type: Date,
+    optional: true,
+    viewableBy: ['guests'],
+    onInsert: document => {
+      return new Date();
+    },
+  },
+
+  userName: {
+    label: 'Your name',
+    type: String,
+    optional: false,
+    viewableBy: ['guests'],
+    insertableBy: ['guests'],
+    editableBy: ['admins'],
+  },
+  sendToEmail: {
+    label: 'Your email',
+    type: String,
+    optional: false,
+    viewableBy: ['guests'],
+    insertableBy: ['guests'],
+    editableBy: ['admins'],
+  },
+  emailContent: {
+    label: 'Write a message',
+    type: String,
+    optional: false,
+    control: 'FormComponentTextarea',
+    viewableBy: ['guests'],
+    insertableBy: ['guests'],
+    editableBy: ['admins'],
+  },
+};
+
+export default schema;

--- a/packages/example-contact-us/lib/modules/index.js
+++ b/packages/example-contact-us/lib/modules/index.js
@@ -1,0 +1,11 @@
+// Collections
+import './contact-us/collection';
+
+// Routes
+import './routes.js';
+
+// Components
+import '../components/Home';
+
+// Forms
+import '../components/forms/contact-us/ContactUsNewForm';

--- a/packages/example-contact-us/lib/modules/routes.js
+++ b/packages/example-contact-us/lib/modules/routes.js
@@ -1,0 +1,9 @@
+import { addRoute, Components } from 'meteor/vulcan:core';
+
+
+
+addRoute({
+  name: 'contact-us',
+  path: '/',
+  componentName: 'ContactUs',
+});

--- a/packages/example-contact-us/lib/server/callbacks/contactUsEmail.js
+++ b/packages/example-contact-us/lib/server/callbacks/contactUsEmail.js
@@ -14,7 +14,7 @@ async function createAutomaticRespondEmail(userInput) {
     "Hi! Thanks for your message ",
     `
     <h3>You wrote:</h3>
-    <p>${emailContent}</p>
+    <p style="white-space:pre-wrap;">${emailContent}</p>
     <br>
     <p>The humans are notified - they'll get it touch soon.</p>
     `,

--- a/packages/example-contact-us/lib/server/callbacks/contactUsEmail.js
+++ b/packages/example-contact-us/lib/server/callbacks/contactUsEmail.js
@@ -1,0 +1,41 @@
+import { addCallback } from 'meteor/vulcan:core';
+import VulcanEmail from 'meteor/vulcan:email';
+
+// TODO: Create a mailto link in the admin mail with a pre-made response based on the inputs
+// Something like using their name in the subject or the start of the email would be awesome!
+
+async function createAutomaticRespondEmail(userInput) {
+  // Destruct the needed fields from userInput
+  const { to, userName, emailContent } = userInput;
+
+  // Send email to the email the quest provided
+  await VulcanEmail.send(
+    to,
+    "Hi! Thanks for your message",
+    `
+    <h3>You wrote:</h3>
+    <p>${emailContent}</p>
+    <br>
+    <p>The humans are notified - they'll get it touch soon.</p>
+    `,
+  );
+
+  // Define a mail that receives notification on guest submissions
+  const toAdmin = 'awesomeVulcanAdmin@vulcan-starter.com';
+
+  // Send email to the admin
+  await VulcanEmail.send(
+    toAdmin,
+    `(ContactUs Submission) ${userName} sent a message `,
+    `
+    <h3>${userName} wrote:</h3>
+    <p>${emailContent}</p>
+    <br>
+    <p>Write them back at the given email: ${to}</p>
+    <br>
+    <p>If you're getting spammed - call or message your admin</p>
+    <p>Best regards, Website Admin</p>
+    `,
+  );
+}
+addCallback('contactusform.new.async', createAutomaticRespondEmail);

--- a/packages/example-contact-us/lib/server/callbacks/contactUsEmail.js
+++ b/packages/example-contact-us/lib/server/callbacks/contactUsEmail.js
@@ -6,12 +6,12 @@ import VulcanEmail from 'meteor/vulcan:email';
 
 async function createAutomaticRespondEmail(userInput) {
   // Destruct the needed fields from userInput
-  const { to, userName, emailContent } = userInput;
+  const { sendToEmail, userName, emailContent } = userInput;
 
   // Send email to the email the quest provided
   await VulcanEmail.send(
-    to,
-    "Hi! Thanks for your message",
+    sendToEmail,
+    "Hi! Thanks for your message ",
     `
     <h3>You wrote:</h3>
     <p>${emailContent}</p>
@@ -21,17 +21,17 @@ async function createAutomaticRespondEmail(userInput) {
   );
 
   // Define a mail that receives notification on guest submissions
-  const toAdmin = 'awesomeVulcanAdmin@vulcan-starter.com';
+  const toAdmin = 'Vulcan Admin <awesomeVulcanAdmin@vulcan-starter.com>';
 
   // Send email to the admin
   await VulcanEmail.send(
     toAdmin,
-    `(ContactUs Submission) ${userName} sent a message `,
+    `Contact-us Form Submission: ${userName} sent a message `,
     `
     <h3>${userName} wrote:</h3>
     <p>${emailContent}</p>
     <br>
-    <p>Write them back at the given email: ${to}</p>
+    <p>Write them back at the given email: ${sendToEmail}</p>
     <br>
     <p>If you're getting spammed - call or message your admin</p>
     <p>Best regards, Website Admin</p>

--- a/packages/example-contact-us/lib/server/callbacks/contactUsEmailValidation.js
+++ b/packages/example-contact-us/lib/server/callbacks/contactUsEmailValidation.js
@@ -1,0 +1,31 @@
+import { addCallback } from 'meteor/vulcan:core';
+import { createError } from 'apollo-errors';
+import {
+  EmailValidation,
+  EmailExp,
+} from 'regular-expression-validation/lib/EmailRegExp';
+
+// Validate the email according to RFC and Mozilla
+// the RegExp used is based on common practices
+// It is expanded to include æøå characters
+async function validateGuestInput(userInput) {
+   try {
+
+    if (!EmailValidation(EmailExp, userInput.sendToEmail)) {
+      const ValidationError = createError('contactUs.validation_error', {
+        message: 'You need to use a proper email address',
+      });
+      throw new ValidationError({
+        data: { break: true, value: EmailValidation },
+      });
+
+    }
+
+  } catch (error) {
+    console.error(`----\nValidation error:`);
+    throw error;
+  }
+  // No error occurred, continue db operation.
+  return userInput;
+}
+addCallback('contactusform.new.before', validateGuestInput);

--- a/packages/example-contact-us/lib/server/callbacks/contactUsRateLimiting.js
+++ b/packages/example-contact-us/lib/server/callbacks/contactUsRateLimiting.js
@@ -54,7 +54,7 @@ async function rateLimitAutomaticRespondEmails(userInput) {
      */
 
   } catch (error) {
-    console.error(`----\nRate-limiting error: \n\n${error.stack}`);
+    console.error(`----\nRate-limiting error:`);
     throw error;
   }
   // No error occurred, continue db operation.

--- a/packages/example-contact-us/lib/server/callbacks/contactUsRateLimiting.js
+++ b/packages/example-contact-us/lib/server/callbacks/contactUsRateLimiting.js
@@ -1,0 +1,63 @@
+import { addCallback } from 'meteor/vulcan:core';
+import { createError } from 'apollo-errors';
+
+import ContactUsForm from '../../modules/contact-us/collection';
+
+/*
+ *  Require the guest to wait more than X seconds between operations
+ */
+
+// Rate-limit database operations from guests
+async function rateLimitAutomaticRespondEmails(userInput) {
+  // Find the latest db entry, sort by creation date
+  const latestDBEntry = await ContactUsForm.findOne(
+    {},
+    { sort: [['createdAt', 'desc']] },
+  );
+
+  // If no entries exist, continue db operation.
+  if(await latestDBEntry === undefined) {
+    return userInput;
+  }
+
+  try {
+    // When was the last db entry in ms?
+    const latestEntryDateMS = Date.parse(latestDBEntry.createdAt);
+    // What time is it?
+    const now = new Date();
+    // How many ms from 1970's to now?
+    const nowMS = Date.parse(now);
+
+    /*
+     * If the last db operation was less than 30 seconds ago;
+     * Return without finishing the operation and
+     * display a client-side message about why the guest have to wait.
+     */
+
+    if (nowMS - latestEntryDateMS < 30000) {
+      const RateLimitError = createError('contactUs.rate_limit_error', {
+        message: 'We are getting a lot of love, please try again soon.',
+      });
+      throw new RateLimitError({
+        data: { break: true, value: nowMS - latestEntryDateMS },
+      });
+
+    }
+
+    /* Let's debug!
+     * console.info(`The latest DB entry: ${latestDBEntry.createdAt}`);
+     * console.info(`Right now: ${now}`);
+     * console.info(`Attempt made at: ${userInput.createdAt}`);
+     * console.info(
+     *   `Time from last attempt to now: ${nowMS - latestEntryDateMS}ms`,
+     * );
+     */
+
+  } catch (error) {
+    console.error(`----\nRate-limiting error: \n\n${error.stack}`);
+    throw error;
+  }
+  // No error occurred, continue db operation.
+  return userInput;
+}
+addCallback('contactusform.new.sync', rateLimitAutomaticRespondEmails);

--- a/packages/example-contact-us/lib/server/main.js
+++ b/packages/example-contact-us/lib/server/main.js
@@ -3,3 +3,4 @@ import '../modules/index.js';
 // Callbacks
 import './callbacks/contactUsEmail';
 import './callbacks/contactUsRateLimiting';
+import './callbacks/contactUsEmailValidation';

--- a/packages/example-contact-us/lib/server/main.js
+++ b/packages/example-contact-us/lib/server/main.js
@@ -1,0 +1,5 @@
+import '../modules/index.js';
+
+// Callbacks
+import './callbacks/contactUsEmail';
+import './callbacks/contactUsRateLimiting';

--- a/packages/example-contact-us/package.js
+++ b/packages/example-contact-us/package.js
@@ -1,0 +1,25 @@
+
+Package.describe({
+  name: 'example-contact-us',
+  summary: "A basic 'contact us' form package",
+  version: '0.1.0',
+});
+
+Package.onUse(function (api) {
+
+  api.use([
+    // vulcan core
+    'vulcan:core@1.8.11',
+
+    // vulcan packages
+    'vulcan:i18n-en-us@1.8.11',
+    'vulcan:forms@1.8.11',
+    'vulcan:email@1.8.11',
+
+  ]);
+
+  // Here is the entry point for client & server:
+  api.mainModule('lib/server/main.js', 'server');
+  api.mainModule('lib/client/main.js', 'client');
+
+});


### PR DESCRIPTION
I was getting weird babel runtime errors on a new install and a version notch fixed it. It probably has something to do with Meteor. [Here is a link to a Meteor forum post addressing it](https://forums.meteor.com/t/meteor-fails-to-start-after-update/42832)


Add a package that utilizes the VulcanEmail .send function to send a confirmation email when a guest wants contact with the 'site admins'. Useful for websites where the customer wants to be in contact with the 'site admins' (e.g. the HR or support team) 

The mutation check on collection.js simply returns the document. This might be too unsafe.
