### PR TITLE
bug fix for schema does not include a "posts.$"

### DIFF
--- a/packages/example-forum/lib/modules/posts/custom_fields.js
+++ b/packages/example-forum/lib/modules/posts/custom_fields.js
@@ -42,5 +42,12 @@ Users.addField([
         }
       }
     }
+  },
+  {
+    fieldName: 'posts.$',
+    fieldSchema: {
+      type: String,
+      optional: true
+    }
   }
 ]);


### PR DESCRIPTION
Fix for bug Error: "posts" is Array type but the schema does not include a "posts.$" definition for the array items"