### PR TITLE
Update PostsApprovedSetPostedAt callback

### DIFF
--- a/packages/example-forum/lib/modules/posts/schema.js
+++ b/packages/example-forum/lib/modules/posts/schema.js
@@ -62,6 +62,12 @@ const schema = {
       if (!post.postedAt && getCollection('Posts').getDefaultStatus(currentUser) === getCollection('Posts').config.STATUS_APPROVED) {
         return new Date();
       }
+    },
+    onEdit: (modifier, post) => {
+      // Set the post's postedAt if it's going to be approved
+      if (!post.postedAt && modifier.$set.status === getCollection('Posts').config.STATUS_APPROVED) {
+        return new Date();
+      }
     }
   },
   /**

--- a/packages/example-forum/lib/server/posts/callbacks/other.js
+++ b/packages/example-forum/lib/server/posts/callbacks/other.js
@@ -101,7 +101,7 @@ addCallback('posts.click.async', PostsClickTracking);
 //////////////////////////////////////////////////////
 
 function PostsApprovedSetPostedAt(modifier, post) {
-  modifier.postedAt = new Date();
+  modifier.$set.postedAt = new Date();
   return modifier;
 }
 addCallback('posts.approve.sync', PostsApprovedSetPostedAt);


### PR DESCRIPTION
This PR resolves https://github.com/VulcanJS/Vulcan/issues/1900

The modifier is being transformed from:

```
{
  '$set': {
    postedAt: 2018-05-02T16:58:52.260Z,
    url: 'https://devnaestrada.com.br/2018/04/27/mundo-de-po.html',
    title: 'Everything else works',
    status: 2,
    sticky: false,
    thumbnailUrl: 'https://assets.libsyn.com/secure/show/104268/dne-154-capa.jpg',
    slug: 'everything-else-works'
  },
 '$unset': {
    body: true, categoriesIds: true
  }
}
```
to:
```
{
  '$set': {
    postedAt: 2018-05-02T16:58:52.260Z,
    url: 'https://devnaestrada.com.br/2018/04/27/mundo-de-po.html',
    title: 'Everything else works',
    status: 2,
    sticky: false,
    thumbnailUrl: 'https://assets.libsyn.com/secure/show/104268/dne-154-capa.jpg',
    slug: 'everything-else-works'
  },
 '$unset': {
    body: true, categoriesIds: true
  },
  postedAt: 2018-05-08T18:56:03.412Z
}
```

Causing the error when attempt to set a post with `approved` status.
