### PR TITLE
Improve consistency of component registration

### DIFF
--- a/packages/example-movies/lib/components/movies/MoviesEditForm.jsx
+++ b/packages/example-movies/lib/components/movies/MoviesEditForm.jsx
@@ -26,4 +26,4 @@ const MoviesEditForm = ({ documentId, closeModal, refetch }) => (
   />
 );
 
-registerComponent({ name: 'MoviesEditForm', component: MoviesEditForm });
+registerComponent('MoviesEditForm', MoviesEditForm);

--- a/packages/example-movies/lib/components/movies/MoviesItem.jsx
+++ b/packages/example-movies/lib/components/movies/MoviesItem.jsx
@@ -31,4 +31,4 @@ const MoviesItem = ({ movie, currentUser, refetch }) => (
   </div>
 );
 
-registerComponent({ name: 'MoviesItem', component: MoviesItem });
+registerComponent('MoviesItem', MoviesItem);

--- a/packages/example-movies/lib/components/movies/MoviesList.jsx
+++ b/packages/example-movies/lib/components/movies/MoviesList.jsx
@@ -49,4 +49,4 @@ const options = {
   limit: 5,
 };
 
-registerComponent({ name: 'MoviesList', component: MoviesList, hocs: [withCurrentUser, [withMulti, options]] });
+registerComponent('MoviesList', MoviesList, withCurrentUser, [withMulti, options]);

--- a/packages/example-movies/lib/components/movies/MoviesNewForm.jsx
+++ b/packages/example-movies/lib/components/movies/MoviesNewForm.jsx
@@ -20,4 +20,4 @@ const MoviesNewForm = ({ currentUser, refetch }) => (
   </div>
 );
 
-registerComponent({ name: 'MoviesNewForm', component: MoviesNewForm, hocs: [withCurrentUser] });
+registerComponent('MoviesNewForm', MoviesNewForm, withCurrentUser);

--- a/packages/example-simple/lib/components/movies/MoviesList.jsx
+++ b/packages/example-simple/lib/components/movies/MoviesList.jsx
@@ -117,7 +117,7 @@ const options = {
 };
 
 // These two functions (withList & withCurrentUser) are Higher Order Components (HOC) and by wrapping our component with this we can give it "props". (See the "props" section at the top.)
-registerComponent({ name: 'MoviesList', component: MoviesList, hocs: [withCurrentUser, [withMulti, options]] });
+registerComponent('MoviesList', MoviesList, withCurrentUser, [withMulti, options]);
 
 // #tutorial-step-12 - Well. that's it! If you like this, go on to the movies-example, where we get more granular when it comes to data loading.
 // Well thanks for tuning in! Come visit us at our chat room at slack.vulcanjs.org. See you soon!

--- a/packages/getting-started/lib/components/steps/Step3.jsx
+++ b/packages/getting-started/lib/components/steps/Step3.jsx
@@ -19,4 +19,4 @@ Now let's learn a couple more Vulcan basics before we start building our little 
 
 const Step3 = () => <Components.Step step={3} text={text} after={after}/>;
 
-// registerComponent({ name: 'Step3', component: Step3}); // uncomment on #Step2
+// registerComponent('Step3', Step3); // uncomment on #Step2


### PR DESCRIPTION
Call `registerComponent` with rest parameters instead of object argument

Also addresses Vulcanjs/vulcan#2061