### PR TITLE
Update registerComponent calls to preferred syntax

### DIFF
--- a/packages/example-customization/lib/components/MyCustomPage.jsx
+++ b/packages/example-customization/lib/components/MyCustomPage.jsx
@@ -15,4 +15,4 @@ const MyCustomPage = () => {
   )
 }
 
-registerComponent('MyCustomPage', MyCustomPage);
+registerComponent({ name: 'MyCustomPage', component: MyCustomPage });

--- a/packages/example-forms/lib/components/FormFunnel.jsx
+++ b/packages/example-forms/lib/components/FormFunnel.jsx
@@ -39,4 +39,4 @@ FormFunnel.contextTypes = {
   updateCurrentValues: PropTypes.func,
 };
 
-registerComponent('FormFunnel', FormFunnel);
+registerComponent({ name: 'FormFunnel', component: FormFunnel });

--- a/packages/example-forms/lib/components/Home.js
+++ b/packages/example-forms/lib/components/Home.js
@@ -53,4 +53,4 @@ const Home = ({ flash }) => (
   </div>
 );
 
-registerComponent('Home', Home, withMessages);
+registerComponent({ name: 'Home', component: Home, hocs: [withMessages] });

--- a/packages/example-forum/lib/components/categories/CategoriesDashboard.jsx
+++ b/packages/example-forum/lib/components/categories/CategoriesDashboard.jsx
@@ -27,4 +27,4 @@ const CategoriesDashboard = () =>
   
   </div>
 
-registerComponent('CategoriesDashboard', CategoriesDashboard);
+registerComponent({ name: 'CategoriesDashboard', component: CategoriesDashboard });

--- a/packages/example-forum/lib/components/categories/CategoriesEditForm.jsx
+++ b/packages/example-forum/lib/components/categories/CategoriesEditForm.jsx
@@ -40,4 +40,4 @@ CategoriesEditForm.contextTypes = {
   intl: intlShape,
 };
 
-registerComponent('CategoriesEditForm', CategoriesEditForm, withMessages);
+registerComponent({ name: 'CategoriesEditForm', component: CategoriesEditForm, hocs: [withMessages] });

--- a/packages/example-forum/lib/components/categories/CategoriesMenu.jsx
+++ b/packages/example-forum/lib/components/categories/CategoriesMenu.jsx
@@ -126,4 +126,4 @@ const options = {
   pollInterval: 0,
 };
 
-registerComponent('CategoriesMenu', CategoriesMenu, withRouter, withApollo, [withList, options], withCurrentUser);
+registerComponent({ name: 'CategoriesMenu', component: CategoriesMenu, hocs: [withRouter, withApollo, [withList, options], withCurrentUser] });

--- a/packages/example-forum/lib/components/categories/CategoriesNewForm.jsx
+++ b/packages/example-forum/lib/components/categories/CategoriesNewForm.jsx
@@ -31,4 +31,4 @@ CategoriesNewForm.contextTypes = {
   intl: intlShape,
 };
 
-registerComponent('CategoriesNewForm', CategoriesNewForm, withMessages);
+registerComponent({ name: 'CategoriesNewForm', component: CategoriesNewForm, hocs: [withMessages] });

--- a/packages/example-forum/lib/components/comments/CommentsEditForm.jsx
+++ b/packages/example-forum/lib/components/comments/CommentsEditForm.jsx
@@ -26,4 +26,4 @@ CommentsEditForm.propTypes = {
   cancelCallback: PropTypes.func
 };
 
-registerComponent('CommentsEditForm', CommentsEditForm, withMessages);
+registerComponent({ name: 'CommentsEditForm', component: CommentsEditForm, hocs: [withMessages] });

--- a/packages/example-forum/lib/components/comments/CommentsItem.jsx
+++ b/packages/example-forum/lib/components/comments/CommentsItem.jsx
@@ -123,4 +123,4 @@ CommentsItem.propTypes = {
   flash: PropTypes.func,
 };
 
-registerComponent('CommentsItem', CommentsItem, withMessages);
+registerComponent({ name: 'CommentsItem', component: CommentsItem, hocs: [withMessages] });

--- a/packages/example-forum/lib/components/comments/CommentsList.jsx
+++ b/packages/example-forum/lib/components/comments/CommentsList.jsx
@@ -25,4 +25,4 @@ const CommentsList = ({comments, commentCount, currentUser}) => {
 
 CommentsList.displayName = "CommentsList";
 
-registerComponent('CommentsList', CommentsList);
+registerComponent({ name: 'CommentsList', component: CommentsList });

--- a/packages/example-forum/lib/components/comments/CommentsLoadMore.jsx
+++ b/packages/example-forum/lib/components/comments/CommentsLoadMore.jsx
@@ -8,4 +8,4 @@ const CommentsLoadMore = ({loadMore, count, totalCount}) => {
 
 CommentsLoadMore.displayName = "CommentsLoadMore";
 
-registerComponent('CommentsLoadMore', CommentsLoadMore);
+registerComponent({ name: 'CommentsLoadMore', component: CommentsLoadMore });

--- a/packages/example-forum/lib/components/comments/CommentsNewForm.jsx
+++ b/packages/example-forum/lib/components/comments/CommentsNewForm.jsx
@@ -48,4 +48,4 @@ CommentsNewForm.propTypes = {
   flash: PropTypes.func,
 };
 
-registerComponent('CommentsNewForm', CommentsNewForm, withMessages);
+registerComponent({ name: 'CommentsNewForm', component: CommentsNewForm, hocs: [withMessages] });

--- a/packages/example-forum/lib/components/comments/CommentsNode.jsx
+++ b/packages/example-forum/lib/components/comments/CommentsNode.jsx
@@ -17,4 +17,4 @@ CommentsNode.propTypes = {
   comment: PropTypes.object.isRequired, // the current comment
 };
 
-registerComponent('CommentsNode', CommentsNode);
+registerComponent({ name: 'CommentsNode', component: CommentsNode });

--- a/packages/example-forum/lib/components/common/Footer.jsx
+++ b/packages/example-forum/lib/components/common/Footer.jsx
@@ -10,4 +10,4 @@ const Footer = props => {
 
 Footer.displayName = "Footer";
 
-registerComponent('Footer', Footer);
+registerComponent({ name: 'Footer', component: Footer });

--- a/packages/example-forum/lib/components/common/Header.jsx
+++ b/packages/example-forum/lib/components/common/Header.jsx
@@ -44,4 +44,4 @@ Header.propTypes = {
   currentUser: PropTypes.object,
 };
 
-registerComponent('Header', Header, withCurrentUser);
+registerComponent({ name: 'Header', component: Header, hocs: [withCurrentUser] });

--- a/packages/example-forum/lib/components/common/Layout.jsx
+++ b/packages/example-forum/lib/components/common/Layout.jsx
@@ -33,4 +33,4 @@ const Layout = ({currentUser, children, currentRoute}) =>
   
   </div>
 
-registerComponent('Layout', Layout, withCurrentUser);
+registerComponent({ name: 'Layout', component: Layout, hocs: [withCurrentUser] });

--- a/packages/example-forum/lib/components/common/Logo.jsx
+++ b/packages/example-forum/lib/components/common/Logo.jsx
@@ -22,4 +22,4 @@ const Logo = ({logoUrl, siteTitle}) => {
 
 Logo.displayName = "Logo";
 
-registerComponent('Logo', Logo);
+registerComponent({ name: 'Logo', component: Logo });

--- a/packages/example-forum/lib/components/common/Newsletter.jsx
+++ b/packages/example-forum/lib/components/common/Newsletter.jsx
@@ -116,4 +116,4 @@ function showBanner (user) {
   );
 }
 
-registerComponent('Newsletter', Newsletter, withMutation(mutationOptions), withCurrentUser, withMessages);
+registerComponent({ name: 'Newsletter', component: Newsletter, hocs: [withMutation(mutationOptions), withCurrentUser, withMessages] });

--- a/packages/example-forum/lib/components/common/NewsletterButton.jsx
+++ b/packages/example-forum/lib/components/common/NewsletterButton.jsx
@@ -60,4 +60,4 @@ NewsletterButton.contextTypes = {
 const addOptions = {name: 'addUserNewsletter', args: {userId: 'String'}};
 const removeOptions = {name: 'removeUserNewsletter', args: {userId: 'String'}};
 
-registerComponent('NewsletterButton', NewsletterButton, withCurrentUser, withMutation(addOptions), withMutation(removeOptions), withMessages);
+registerComponent({ name: 'NewsletterButton', component: NewsletterButton, hocs: [withCurrentUser, withMutation(addOptions), withMutation(removeOptions), withMessages] });

--- a/packages/example-forum/lib/components/common/SearchForm.jsx
+++ b/packages/example-forum/lib/components/common/SearchForm.jsx
@@ -78,4 +78,4 @@ SearchForm.contextTypes = {
   intl: intlShape
 };
 
-registerComponent('SearchForm', SearchForm, withRouter);
+registerComponent({ name: 'SearchForm', component: SearchForm, hocs: [withRouter] });

--- a/packages/example-forum/lib/components/common/Vote.jsx
+++ b/packages/example-forum/lib/components/common/Vote.jsx
@@ -68,4 +68,4 @@ Vote.contextTypes = {
   intl: intlShape
 };
 
-registerComponent('Vote', Vote, withMessages, withVote);
+registerComponent({ name: 'Vote', component: Vote, hocs: [withMessages, withVote] });

--- a/packages/example-forum/lib/components/posts/PostsCategories.jsx
+++ b/packages/example-forum/lib/components/posts/PostsCategories.jsx
@@ -14,4 +14,4 @@ const PostsCategories = ({post}) => {
 
 PostsCategories.displayName = "PostsCategories";
 
-registerComponent('PostsCategories', PostsCategories);
+registerComponent({ name: 'PostsCategories', component: PostsCategories });

--- a/packages/example-forum/lib/components/posts/PostsCommenters.jsx
+++ b/packages/example-forum/lib/components/posts/PostsCommenters.jsx
@@ -22,4 +22,4 @@ const PostsCommenters = ({post}) => {
 
 PostsCommenters.displayName = "PostsCommenters";
 
-registerComponent('PostsCommenters', PostsCommenters);
+registerComponent({ name: 'PostsCommenters', component: PostsCommenters });

--- a/packages/example-forum/lib/components/posts/PostsCommentsThread.jsx
+++ b/packages/example-forum/lib/components/posts/PostsCommentsThread.jsx
@@ -52,4 +52,4 @@ const options = {
   limit: 0,
 };
 
-registerComponent('PostsCommentsThread', PostsCommentsThread, [withList, options], withCurrentUser);
+registerComponent({ name: 'PostsCommentsThread', component: PostsCommentsThread, hocs: [[withList, options], withCurrentUser] });

--- a/packages/example-forum/lib/components/posts/PostsDaily.jsx
+++ b/packages/example-forum/lib/components/posts/PostsDaily.jsx
@@ -19,4 +19,4 @@ const PostsDaily = props => {
 
 PostsDaily.displayName = 'PostsDaily';
 
-registerComponent('PostsDaily', PostsDaily);
+registerComponent({ name: 'PostsDaily', component: PostsDaily });

--- a/packages/example-forum/lib/components/posts/PostsDailyList.jsx
+++ b/packages/example-forum/lib/components/posts/PostsDailyList.jsx
@@ -116,4 +116,4 @@ const options = {
   limit: 0,
 };
 
-registerComponent('PostsDailyList', PostsDailyList, withCurrentUser, [withList, options]);
+registerComponent({ name: 'PostsDailyList', component: PostsDailyList, hocs: [withCurrentUser, [withList, options]] });

--- a/packages/example-forum/lib/components/posts/PostsDay.jsx
+++ b/packages/example-forum/lib/components/posts/PostsDay.jsx
@@ -29,4 +29,4 @@ PostsDay.propTypes = {
   number: PropTypes.number
 };
 
-registerComponent('PostsDay', PostsDay);
+registerComponent({ name: 'PostsDay', component: PostsDay });

--- a/packages/example-forum/lib/components/posts/PostsEditForm.jsx
+++ b/packages/example-forum/lib/components/posts/PostsEditForm.jsx
@@ -61,4 +61,4 @@ PostsEditForm.contextTypes = {
   intl: intlShape
 }
 
-registerComponent('PostsEditForm', PostsEditForm, withMessages, withRouter, withCurrentUser);
+registerComponent({ name: 'PostsEditForm', component: PostsEditForm, hocs: [withMessages, withRouter, withCurrentUser] });

--- a/packages/example-forum/lib/components/posts/PostsHome.jsx
+++ b/packages/example-forum/lib/components/posts/PostsHome.jsx
@@ -9,4 +9,4 @@ const PostsHome = (props, context) => {
 
 PostsHome.displayName = "PostsHome";
 
-registerComponent('PostsHome', PostsHome);
+registerComponent({ name: 'PostsHome', component: PostsHome });

--- a/packages/example-forum/lib/components/posts/PostsItem.jsx
+++ b/packages/example-forum/lib/components/posts/PostsItem.jsx
@@ -81,4 +81,4 @@ PostsItem.propTypes = {
   terms: PropTypes.object,
 };
 
-registerComponent('PostsItem', PostsItem);
+registerComponent({ name: 'PostsItem', component: PostsItem });

--- a/packages/example-forum/lib/components/posts/PostsList.jsx
+++ b/packages/example-forum/lib/components/posts/PostsList.jsx
@@ -77,4 +77,4 @@ const options = {
   fragmentName: 'PostsList',
 };
 
-registerComponent('PostsList', PostsList, withCurrentUser, [withList, options]);
+registerComponent({ name: 'PostsList', component: PostsList, hocs: [withCurrentUser, [withList, options]] });

--- a/packages/example-forum/lib/components/posts/PostsListHeader.jsx
+++ b/packages/example-forum/lib/components/posts/PostsListHeader.jsx
@@ -18,4 +18,4 @@ const PostsListHeader = () => {
 
 PostsListHeader.displayName = "PostsListHeader";
 
-registerComponent('PostsListHeader', PostsListHeader);
+registerComponent({ name: 'PostsListHeader', component: PostsListHeader });

--- a/packages/example-forum/lib/components/posts/PostsLoadMore.jsx
+++ b/packages/example-forum/lib/components/posts/PostsLoadMore.jsx
@@ -18,4 +18,4 @@ const PostsLoadMore = ({loading, loadMore, count, totalCount}) => {
 
 PostsLoadMore.displayName = "PostsLoadMore";
 
-registerComponent('PostsLoadMore', PostsLoadMore);
+registerComponent({ name: 'PostsLoadMore', component: PostsLoadMore });

--- a/packages/example-forum/lib/components/posts/PostsLoading.jsx
+++ b/packages/example-forum/lib/components/posts/PostsLoading.jsx
@@ -7,4 +7,4 @@ const PostsLoading = props => {
 
 PostsLoading.displayName = "PostsLoading";
 
-registerComponent('PostsLoading', PostsLoading);
+registerComponent({ name: 'PostsLoading', component: PostsLoading });

--- a/packages/example-forum/lib/components/posts/PostsNewButton.jsx
+++ b/packages/example-forum/lib/components/posts/PostsNewButton.jsx
@@ -25,4 +25,4 @@ PostsNewButton.contextTypes = {
   intl: intlShape
 };
 
-registerComponent('PostsNewButton', PostsNewButton, withCurrentUser);
+registerComponent({ name: 'PostsNewButton', component: PostsNewButton, hocs: [withCurrentUser] });

--- a/packages/example-forum/lib/components/posts/PostsNewForm.jsx
+++ b/packages/example-forum/lib/components/posts/PostsNewForm.jsx
@@ -64,4 +64,4 @@ const options = {
   pollInterval: 0,
 };
 
-registerComponent('PostsNewForm', PostsNewForm, withRouter, withMessages, [withList, options]);
+registerComponent({ name: 'PostsNewForm', component: PostsNewForm, hocs: [withRouter, withMessages, [withList, options]] });

--- a/packages/example-forum/lib/components/posts/PostsNoMore.jsx
+++ b/packages/example-forum/lib/components/posts/PostsNoMore.jsx
@@ -6,4 +6,4 @@ const PostsNoMore = props => <p className="posts-no-more"><FormattedMessage id="
 
 PostsNoMore.displayName = "PostsNoMore";
 
-registerComponent('PostsNoMore', PostsNoMore);
+registerComponent({ name: 'PostsNoMore', component: PostsNoMore });

--- a/packages/example-forum/lib/components/posts/PostsNoResults.jsx
+++ b/packages/example-forum/lib/components/posts/PostsNoResults.jsx
@@ -6,4 +6,4 @@ const PostsNoResults = props => <p className="posts-no-results"><FormattedMessag
 
 PostsNoResults.displayName = "PostsNoResults";
 
-registerComponent('PostsNoResults', PostsNoResults);
+registerComponent({ name: 'PostsNoResults', component: PostsNoResults });

--- a/packages/example-forum/lib/components/posts/PostsSingle.jsx
+++ b/packages/example-forum/lib/components/posts/PostsSingle.jsx
@@ -7,4 +7,4 @@ const PostsSingle = (props, context) => {
 
 PostsSingle.displayName = "PostsSingle";
 
-registerComponent('PostsSingle', PostsSingle);
+registerComponent({ name: 'PostsSingle', component: PostsSingle });

--- a/packages/example-forum/lib/components/posts/PostsStats.jsx
+++ b/packages/example-forum/lib/components/posts/PostsStats.jsx
@@ -15,4 +15,4 @@ const PostsStats = ({post}) => {
 
 PostsStats.displayName = "PostsStats";
 
-registerComponent('PostsStats', PostsStats);
+registerComponent({ name: 'PostsStats', component: PostsStats });

--- a/packages/example-forum/lib/components/posts/PostsThumbnail.jsx
+++ b/packages/example-forum/lib/components/posts/PostsThumbnail.jsx
@@ -9,4 +9,4 @@ const PostsThumbnail = ({post}) =>
 
 PostsThumbnail.displayName = "PostsThumbnail";
 
-registerComponent('PostsThumbnail', PostsThumbnail);
+registerComponent({ name: 'PostsThumbnail', component: PostsThumbnail });

--- a/packages/example-forum/lib/components/posts/PostsViews.jsx
+++ b/packages/example-forum/lib/components/posts/PostsViews.jsx
@@ -51,4 +51,4 @@ PostsViews.contextTypes = {
 
 PostsViews.displayName = 'PostsViews';
 
-registerComponent('PostsViews', PostsViews, withCurrentUser, withRouter);
+registerComponent({ name: 'PostsViews', component: PostsViews, hocs: [withCurrentUser, withRouter] });

--- a/packages/example-forum/lib/components/users/UsersAccount.jsx
+++ b/packages/example-forum/lib/components/users/UsersAccount.jsx
@@ -14,4 +14,4 @@ UsersAccount.propTypes = {
 
 UsersAccount.displayName = 'UsersAccount';
 
-registerComponent('UsersAccount', UsersAccount, withCurrentUser);
+registerComponent({ name: 'UsersAccount', component: UsersAccount, hocs: [withCurrentUser] });

--- a/packages/example-forum/lib/components/users/UsersAccountMenu.jsx
+++ b/packages/example-forum/lib/components/users/UsersAccountMenu.jsx
@@ -22,4 +22,4 @@ const UsersAccountMenu = ({ state }) => (
 
 UsersAccountMenu.displayName = 'UsersAccountMenu';
 
-registerComponent('UsersAccountMenu', UsersAccountMenu);
+registerComponent({ name: 'UsersAccountMenu', component: UsersAccountMenu });

--- a/packages/example-forum/lib/components/users/UsersAvatar.jsx
+++ b/packages/example-forum/lib/components/users/UsersAvatar.jsx
@@ -40,4 +40,4 @@ UsersAvatar.defaultProps = {
 
 UsersAvatar.displayName = 'UsersAvatar';
 
-registerComponent('UsersAvatar', UsersAvatar);
+registerComponent({ name: 'UsersAvatar', component: UsersAvatar });

--- a/packages/example-forum/lib/components/users/UsersEditForm.jsx
+++ b/packages/example-forum/lib/components/users/UsersEditForm.jsx
@@ -45,4 +45,4 @@ UsersEditForm.contextTypes = {
 
 UsersEditForm.displayName = 'UsersEditForm';
 
-registerComponent('UsersEditForm', UsersEditForm, withMessages, withCurrentUser);
+registerComponent({ name: 'UsersEditForm', component: UsersEditForm, hocs: [withMessages, withCurrentUser] });

--- a/packages/example-forum/lib/components/users/UsersMenu.jsx
+++ b/packages/example-forum/lib/components/users/UsersMenu.jsx
@@ -58,4 +58,4 @@ UsersMenu.propsTypes = {
   client: PropTypes.object,
 };
 
-registerComponent('UsersMenu', UsersMenu, withCurrentUser, withApollo);
+registerComponent({ name: 'UsersMenu', component: UsersMenu, hocs: [withCurrentUser, withApollo] });

--- a/packages/example-forum/lib/components/users/UsersName.jsx
+++ b/packages/example-forum/lib/components/users/UsersName.jsx
@@ -12,4 +12,4 @@ UsersName.propTypes = {
 
 UsersName.displayName = 'UsersName';
 
-registerComponent('UsersName', UsersName);
+registerComponent({ name: 'UsersName', component: UsersName });

--- a/packages/example-forum/lib/components/users/UsersProfile.jsx
+++ b/packages/example-forum/lib/components/users/UsersProfile.jsx
@@ -51,4 +51,4 @@ const options = {
   fragmentName: 'UsersProfile',
 };
 
-registerComponent('UsersProfile', UsersProfile, withCurrentUser, [withDocument, options]);
+registerComponent({ name: 'UsersProfile', component: UsersProfile, hocs: [withCurrentUser, [withDocument, options]] });

--- a/packages/example-forum/lib/components/users/UsersProfileCheck.jsx
+++ b/packages/example-forum/lib/components/users/UsersProfileCheck.jsx
@@ -79,4 +79,4 @@ const options = {
   fragment: mustCompleteFragment,
 };
 
-registerComponent('UsersProfileCheck', UsersProfileCheck, withMessages, [withDocument, options]);
+registerComponent({ name: 'UsersProfileCheck', component: UsersProfileCheck, hocs: [withMessages, [withDocument, options]] });

--- a/packages/example-forum/lib/components/users/UsersSingle.jsx
+++ b/packages/example-forum/lib/components/users/UsersSingle.jsx
@@ -7,4 +7,4 @@ const UsersSingle = (props, context) => {
 
 UsersSingle.displayName = "UsersSingle";
 
-registerComponent('UsersSingle', UsersSingle);
+registerComponent({ name: 'UsersSingle', component: UsersSingle });

--- a/packages/example-instagram/lib/components/comments/CommentsEditForm.jsx
+++ b/packages/example-instagram/lib/components/comments/CommentsEditForm.jsx
@@ -32,4 +32,4 @@ const CommentsEditForm = ({documentId, closeModal}) =>
     }}
   />
 
-registerComponent('CommentsEditForm', CommentsEditForm);
+registerComponent({ name: 'CommentsEditForm', component: CommentsEditForm });

--- a/packages/example-instagram/lib/components/comments/CommentsItem.jsx
+++ b/packages/example-instagram/lib/components/comments/CommentsItem.jsx
@@ -31,4 +31,4 @@ const CommentsItem = ({comment, currentUser}) =>
 
   </div>
 
-registerComponent('CommentsItem', CommentsItem);
+registerComponent({ name: 'CommentsItem', component: CommentsItem });

--- a/packages/example-instagram/lib/components/comments/CommentsList.jsx
+++ b/packages/example-instagram/lib/components/comments/CommentsList.jsx
@@ -33,4 +33,4 @@ const options = {
   fragmentName: 'CommentsItemFragment',
 };
 
-registerComponent('CommentsList', CommentsList, withCurrentUser, [withList, options]);
+registerComponent({ name: 'CommentsList', component: CommentsList, hocs: [withCurrentUser, [withList, options]] });

--- a/packages/example-instagram/lib/components/comments/CommentsNewForm.jsx
+++ b/packages/example-instagram/lib/components/comments/CommentsNewForm.jsx
@@ -26,4 +26,4 @@ const CommentsNewForm = ({picId}) =>
 
   </div>
 
-registerComponent('CommentsNewForm', CommentsNewForm);
+registerComponent({ name: 'CommentsNewForm', component: CommentsNewForm });

--- a/packages/example-instagram/lib/components/common/Header.jsx
+++ b/packages/example-instagram/lib/components/common/Header.jsx
@@ -71,4 +71,4 @@ const Header = ({currentUser}) =>
 
   </div>
 
-registerComponent('Header', Header, withCurrentUser);
+registerComponent({ name: 'Header', component: Header, hocs: [withCurrentUser] });

--- a/packages/example-instagram/lib/components/pics/PicsDetails.jsx
+++ b/packages/example-instagram/lib/components/pics/PicsDetails.jsx
@@ -65,4 +65,4 @@ const options = {
   fragmentName: 'PicsDetailsFragment',
 };
 
-registerComponent('PicsDetails', PicsDetails, [withDocument, options]);
+registerComponent({ name: 'PicsDetails', component: PicsDetails, hocs: [[withDocument, options]] });

--- a/packages/example-instagram/lib/components/pics/PicsEditForm.jsx
+++ b/packages/example-instagram/lib/components/pics/PicsEditForm.jsx
@@ -21,4 +21,4 @@ const PicsEditForm = ({documentId, closeModal}) =>
     }}
   />
 
-registerComponent('PicsEditForm', PicsEditForm);
+registerComponent({ name: 'PicsEditForm', component: PicsEditForm });

--- a/packages/example-instagram/lib/components/pics/PicsItem.jsx
+++ b/packages/example-instagram/lib/components/pics/PicsItem.jsx
@@ -25,4 +25,4 @@ const PicsItem = ({pic, currentUser}) =>
 
   </div>
 
-registerComponent('PicsItem', PicsItem);
+registerComponent({ name: 'PicsItem', component: PicsItem });

--- a/packages/example-instagram/lib/components/pics/PicsList.jsx
+++ b/packages/example-instagram/lib/components/pics/PicsList.jsx
@@ -33,4 +33,4 @@ const options = {
   limit: 6
 };
 
-registerComponent('PicsList', PicsList, withCurrentUser, [withList, options]);
+registerComponent({ name: 'PicsList', component: PicsList, hocs: [withCurrentUser, [withList, options]] });

--- a/packages/example-instagram/lib/components/pics/PicsNewForm.jsx
+++ b/packages/example-instagram/lib/components/pics/PicsNewForm.jsx
@@ -26,4 +26,4 @@ const accessOptions = {
   groups: ['members', 'admins'],
 };
 
-registerComponent('PicsNewForm', PicsNewForm, [withAccess, accessOptions]);
+registerComponent({ name: 'PicsNewForm', component: PicsNewForm, hocs: [[withAccess, accessOptions]] });

--- a/packages/example-interfaces/lib/components/categories/CategoriesEditForm.jsx
+++ b/packages/example-interfaces/lib/components/categories/CategoriesEditForm.jsx
@@ -21,4 +21,4 @@ const CategoriesEditForm = ({documentId, closeModal}) =>
     }}
   />
 
-registerComponent('CategoriesEditForm', CategoriesEditForm);
+registerComponent({ name: 'CategoriesEditForm', component: CategoriesEditForm });

--- a/packages/example-interfaces/lib/components/categories/CategoriesItem.jsx
+++ b/packages/example-interfaces/lib/components/categories/CategoriesItem.jsx
@@ -46,4 +46,4 @@ const CategoriesItem = ({category, currentUser}) =>
 
   </div>
 
-registerComponent('CategoriesItem', CategoriesItem);
+registerComponent({ name: 'CategoriesItem', component: CategoriesItem });

--- a/packages/example-interfaces/lib/components/categories/CategoriesList.jsx
+++ b/packages/example-interfaces/lib/components/categories/CategoriesList.jsx
@@ -42,4 +42,4 @@ const options = {
   limit: 0,
 };
 
-registerComponent('CategoriesList', CategoriesList, withCurrentUser, [withList, options]);
+registerComponent({ name: 'CategoriesList', component: CategoriesList, hocs: [withCurrentUser, [withList, options]] });

--- a/packages/example-interfaces/lib/components/categories/CategoriesNewForm.jsx
+++ b/packages/example-interfaces/lib/components/categories/CategoriesNewForm.jsx
@@ -32,4 +32,4 @@ const CategoriesNewForm = ({currentUser, closeModal, parentId}) =>
 
   </div>
 
-registerComponent('CategoriesNewForm', CategoriesNewForm, withCurrentUser);
+registerComponent({ name: 'CategoriesNewForm', component: CategoriesNewForm, hocs: [withCurrentUser] });

--- a/packages/example-interfaces/lib/components/categories/CategoriesPage.jsx
+++ b/packages/example-interfaces/lib/components/categories/CategoriesPage.jsx
@@ -26,4 +26,4 @@ const CategoriesPage = ({results = [], currentUser, loading, loadMore, count, to
 
   </div>
 
-registerComponent('CategoriesPage', CategoriesPage, withCurrentUser);
+registerComponent({ name: 'CategoriesPage', component: CategoriesPage, hocs: [withCurrentUser] });

--- a/packages/example-membership/lib/components/common/Header.jsx
+++ b/packages/example-membership/lib/components/common/Header.jsx
@@ -73,4 +73,4 @@ const Header = ({currentUser}) =>
 
   </div>
 
-registerComponent('Header', Header, withCurrentUser);
+registerComponent({ name: 'Header', component: Header, hocs: [withCurrentUser] });

--- a/packages/example-membership/lib/components/pics/PicsDetails.jsx
+++ b/packages/example-membership/lib/components/pics/PicsDetails.jsx
@@ -57,4 +57,4 @@ const options = {
   fragmentName: 'PicsDetailsFragment',
 };
 
-registerComponent('PicsDetails', PicsDetails, [withDocument, options]);
+registerComponent({ name: 'PicsDetails', component: PicsDetails, hocs: [[withDocument, options]] });

--- a/packages/example-membership/lib/components/pics/PicsEditForm.jsx
+++ b/packages/example-membership/lib/components/pics/PicsEditForm.jsx
@@ -21,4 +21,4 @@ const PicsEditForm = ({documentId, closeModal}) =>
     }}
   />
 
-registerComponent('PicsEditForm', PicsEditForm);
+registerComponent({ name: 'PicsEditForm', component: PicsEditForm });

--- a/packages/example-membership/lib/components/pics/PicsHome.jsx
+++ b/packages/example-membership/lib/components/pics/PicsHome.jsx
@@ -43,4 +43,4 @@ const PicsHome = ({results = [], currentUser, loading, loadMore, count, totalCou
   
 };
 
-registerComponent('PicsHome', PicsHome, withCurrentUser);
+registerComponent({ name: 'PicsHome', component: PicsHome, hocs: [withCurrentUser] });

--- a/packages/example-membership/lib/components/pics/PicsItem.jsx
+++ b/packages/example-membership/lib/components/pics/PicsItem.jsx
@@ -17,4 +17,4 @@ const PicsItem = ({pic, currentUser}) =>
 
   </div>
 
-registerComponent('PicsItem', PicsItem);
+registerComponent({ name: 'PicsItem', component: PicsItem });

--- a/packages/example-membership/lib/components/pics/PicsList.jsx
+++ b/packages/example-membership/lib/components/pics/PicsList.jsx
@@ -33,4 +33,4 @@ const options = {
   limit: 6
 };
 
-registerComponent('PicsList', PicsList, withCurrentUser, [withList, options]);
+registerComponent({ name: 'PicsList', component: PicsList, hocs: [withCurrentUser, [withList, options]] });

--- a/packages/example-membership/lib/components/pics/PicsNewForm.jsx
+++ b/packages/example-membership/lib/components/pics/PicsNewForm.jsx
@@ -24,4 +24,4 @@ const accessOptions = {
   groups: ['customers', 'admins'],
 };
 
-registerComponent('PicsNewForm', PicsNewForm, [withAccess, accessOptions]);
+registerComponent({ name: 'PicsNewForm', component: PicsNewForm, hocs: [[withAccess, accessOptions]] });

--- a/packages/example-permissions/lib/components/comments/CommentsEditForm.jsx
+++ b/packages/example-permissions/lib/components/comments/CommentsEditForm.jsx
@@ -32,4 +32,4 @@ const CommentsEditForm = ({documentId, closeModal}) =>
     }}
   />
 
-registerComponent('CommentsEditForm', CommentsEditForm);
+registerComponent({ name: 'CommentsEditForm', component: CommentsEditForm });

--- a/packages/example-permissions/lib/components/comments/CommentsItem.jsx
+++ b/packages/example-permissions/lib/components/comments/CommentsItem.jsx
@@ -31,4 +31,4 @@ const CommentsItem = ({comment, currentUser, pic}) =>
 
   </div>
 
-registerComponent('CommentsItem', CommentsItem);
+registerComponent({ name: 'CommentsItem', component: CommentsItem });

--- a/packages/example-permissions/lib/components/comments/CommentsList.jsx
+++ b/packages/example-permissions/lib/components/comments/CommentsList.jsx
@@ -33,4 +33,4 @@ const options = {
   fragmentName: 'CommentsItemFragment',
 };
 
-registerComponent('CommentsList', CommentsList, withCurrentUser, [withList, options]);
+registerComponent({ name: 'CommentsList', component: CommentsList, hocs: [withCurrentUser, [withList, options]] });

--- a/packages/example-permissions/lib/components/comments/CommentsNewForm.jsx
+++ b/packages/example-permissions/lib/components/comments/CommentsNewForm.jsx
@@ -26,4 +26,4 @@ const CommentsNewForm = ({picId}) =>
 
   </div>
 
-registerComponent('CommentsNewForm', CommentsNewForm);
+registerComponent({ name: 'CommentsNewForm', component: CommentsNewForm });

--- a/packages/example-permissions/lib/components/common/Header.jsx
+++ b/packages/example-permissions/lib/components/common/Header.jsx
@@ -74,4 +74,4 @@ const Header = ({currentUser}) =>
 
   </div>
 
-registerComponent('Header', Header, withCurrentUser);
+registerComponent({ name: 'Header', component: Header, hocs: [withCurrentUser] });

--- a/packages/example-permissions/lib/components/pics/PicsDetails.jsx
+++ b/packages/example-permissions/lib/components/pics/PicsDetails.jsx
@@ -65,4 +65,4 @@ const options = {
   fragmentName: 'PicsDetailsFragment',
 };
 
-registerComponent('PicsDetails', PicsDetails, [withDocument, options]);
+registerComponent({ name: 'PicsDetails', component: PicsDetails, hocs: [[withDocument, options]] });

--- a/packages/example-permissions/lib/components/pics/PicsEditForm.jsx
+++ b/packages/example-permissions/lib/components/pics/PicsEditForm.jsx
@@ -21,4 +21,4 @@ const PicsEditForm = ({documentId, closeModal}) =>
     }}
   />
 
-registerComponent('PicsEditForm', PicsEditForm);
+registerComponent({ name: 'PicsEditForm', component: PicsEditForm });

--- a/packages/example-permissions/lib/components/pics/PicsItem.jsx
+++ b/packages/example-permissions/lib/components/pics/PicsItem.jsx
@@ -25,4 +25,4 @@ const PicsItem = ({pic, currentUser}) =>
 
   </div>
 
-registerComponent('PicsItem', PicsItem);
+registerComponent({ name: 'PicsItem', component: PicsItem });

--- a/packages/example-permissions/lib/components/pics/PicsList.jsx
+++ b/packages/example-permissions/lib/components/pics/PicsList.jsx
@@ -34,4 +34,4 @@ const options = {
   limit: 6
 };
 
-registerComponent('PicsList', PicsList, withCurrentUser, [withList, options]);
+registerComponent({ name: 'PicsList', component: PicsList, hocs: [withCurrentUser, [withList, options]] });

--- a/packages/example-permissions/lib/components/pics/PicsNewForm.jsx
+++ b/packages/example-permissions/lib/components/pics/PicsNewForm.jsx
@@ -27,4 +27,4 @@ const PicsNewForm = ({currentUser, closeModal}) =>
 
   </div>
 
-registerComponent('PicsNewForm', PicsNewForm, withCurrentUser);
+registerComponent({ name: 'PicsNewForm', component: PicsNewForm, hocs: [withCurrentUser] });

--- a/packages/example-reactions/lib/components/movies/MoviesList.jsx
+++ b/packages/example-reactions/lib/components/movies/MoviesList.jsx
@@ -65,4 +65,4 @@ const MoviesList = ({results = [], currentUser, loading, loadMore, count, totalC
 
   </div>
 
-registerComponent('MoviesList', MoviesList, withCurrentUser);
+registerComponent({ name: 'MoviesList', component: MoviesList, hocs: [withCurrentUser] });

--- a/packages/example-reactions/lib/components/movies/MyReactions.jsx
+++ b/packages/example-reactions/lib/components/movies/MyReactions.jsx
@@ -82,4 +82,4 @@ const options = {
 
 const mapPropsFunction = props => ({...props, documentId: props.currentUser && props.currentUser._id});
 
-registerComponent('MyReactions', MyReactions, withCurrentUser, mapProps(mapPropsFunction), [withDocument, options]);
+registerComponent({ name: 'MyReactions', component: MyReactions, hocs: [withCurrentUser, mapProps(mapPropsFunction), [withDocument, options]] });

--- a/packages/example-reactions/lib/components/movies/MyReactions2.jsx
+++ b/packages/example-reactions/lib/components/movies/MyReactions2.jsx
@@ -40,4 +40,4 @@ const options = {
 
 const mapPropsFunction = props => ({...props, documentId: props.currentUser && props.currentUser._id});
 
-registerComponent('MyReactions2', MyReactions2, withCurrentUser, mapProps(mapPropsFunction), [withDocument, options]);
+registerComponent({ name: 'MyReactions2', component: MyReactions2, hocs: [withCurrentUser, mapProps(mapPropsFunction), [withDocument, options]] });

--- a/packages/example-reactions/lib/components/movies/Reaction.jsx
+++ b/packages/example-reactions/lib/components/movies/Reaction.jsx
@@ -60,4 +60,4 @@ Reaction.propTypes = {
   currentUser: PropTypes.object, // user might not be logged in, so don't make it required
 };
 
-registerComponent('Reaction', Reaction, withMessages, withVote);
+registerComponent({ name: 'Reaction', component: Reaction, hocs: [withMessages, withVote] });

--- a/packages/getting-started/lib/components/movies/MoviesApp.jsx
+++ b/packages/getting-started/lib/components/movies/MoviesApp.jsx
@@ -11,4 +11,4 @@ const MoviesApp = () => (
   </div>
 );
 
-registerComponent('MoviesApp', MoviesApp);
+registerComponent({ name: 'MoviesApp', component: MoviesApp });

--- a/packages/getting-started/lib/components/movies/MoviesList.jsx
+++ b/packages/getting-started/lib/components/movies/MoviesList.jsx
@@ -27,4 +27,4 @@ const options = {
   // fragmentName: 'MoviesFragment', // uncomment on #Step11
 }
 
-registerComponent('MoviesList', MoviesList, /* [withMulti, options] */); // uncomment on #Step10
+registerComponent({ name: 'MoviesList', component: MoviesList, hocs: [/* [withMulti, options] */] }); // uncomment on #Step10

--- a/packages/getting-started/lib/components/movies/MoviesNew.jsx
+++ b/packages/getting-started/lib/components/movies/MoviesNew.jsx
@@ -10,4 +10,4 @@ const MoviesNew = () => (
   </div>
 );
 
-registerComponent('MoviesNew', MoviesNew);
+registerComponent({ name: 'MoviesNew', component: MoviesNew });

--- a/packages/getting-started/lib/components/movies/MoviesUsers.jsx
+++ b/packages/getting-started/lib/components/movies/MoviesUsers.jsx
@@ -14,4 +14,4 @@ const MoviesUsers = ({ currentUser }) => (
   </div>
 );
 
-registerComponent('MoviesUsers', MoviesUsers, withCurrentUser);
+registerComponent({ name: 'MoviesUsers', component: MoviesUsers, hocs: [withCurrentUser] });

--- a/packages/getting-started/lib/components/other/GraphQLSchema.jsx
+++ b/packages/getting-started/lib/components/other/GraphQLSchema.jsx
@@ -12,4 +12,4 @@ const GraphQLSchema = ({ data }) => (
   </div>
 );
 
-registerComponent('GraphQLSchema', GraphQLSchema);
+registerComponent({ name: 'GraphQLSchema', component: GraphQLSchema });

--- a/packages/getting-started/lib/components/other/Nav.jsx
+++ b/packages/getting-started/lib/components/other/Nav.jsx
@@ -32,4 +32,4 @@ const Nav = (props) => {
   )
 };
 
-registerComponent('Nav', Nav, withMoviesCount, withQueryResolvers, withCurrentUser, withMutationResolvers);
+registerComponent({ name: 'Nav', component: Nav, hocs: [withMoviesCount, withQueryResolvers, withCurrentUser, withMutationResolvers] });

--- a/packages/getting-started/lib/components/other/Schema.jsx
+++ b/packages/getting-started/lib/components/other/Schema.jsx
@@ -59,4 +59,4 @@ const Schema = () => (
   </div>
 );
 
-registerComponent('Schema', Schema);
+registerComponent({ name: 'Schema', component: Schema });

--- a/packages/getting-started/lib/components/steps/Step.jsx
+++ b/packages/getting-started/lib/components/steps/Step.jsx
@@ -102,4 +102,4 @@ const Step = props => {
   );
 };
 
-registerComponent('Step', Step, withCurrentUser);
+registerComponent({ name: 'Step', component: Step, hocs: [withCurrentUser] });

--- a/packages/getting-started/lib/components/steps/Step0.jsx
+++ b/packages/getting-started/lib/components/steps/Step0.jsx
@@ -54,4 +54,4 @@ If you get stuck at any point, drop by the [Vulcan Slack group](http://slack.vul
 
 const Step0 = () => <Components.Step step={0} text={text} firstStep={true}/>;
 
-registerComponent('Step0', Step0);
+registerComponent({ name: 'Step0', component: Step0 });

--- a/packages/getting-started/lib/components/steps/Step1.jsx
+++ b/packages/getting-started/lib/components/steps/Step1.jsx
@@ -21,4 +21,4 @@ By the way, when developing locally you can review all your routes using the [Ro
 
 const Step1 = () => <Components.Step step={1} text={text} after={after}/>;
 
-registerComponent('Step1', Step1);
+registerComponent({ name: 'Step1', component: Step1 });

--- a/packages/getting-started/lib/components/steps/Step10.jsx
+++ b/packages/getting-started/lib/components/steps/Step10.jsx
@@ -21,4 +21,4 @@ const Step10 = () => (
   <Components.Step step={10} text={text} after={after} />
 );
 
-registerComponent('Step10', Step10);
+registerComponent({ name: 'Step10', component: Step10 });

--- a/packages/getting-started/lib/components/steps/Step11.jsx
+++ b/packages/getting-started/lib/components/steps/Step11.jsx
@@ -31,4 +31,4 @@ const Step11 = () => (
   <Components.Step step={11} text={text} after={after} />
 );
 
-registerComponent('Step11', Step11);
+registerComponent({ name: 'Step11', component: Step11 });

--- a/packages/getting-started/lib/components/steps/Step12.jsx
+++ b/packages/getting-started/lib/components/steps/Step12.jsx
@@ -58,4 +58,4 @@ const Step12 = () => (
   <Components.Step step={12} text={text} after={after} />
 );
 
-registerComponent('Step12', Step12);
+registerComponent({ name: 'Step12', component: Step12 });

--- a/packages/getting-started/lib/components/steps/Step13.jsx
+++ b/packages/getting-started/lib/components/steps/Step13.jsx
@@ -27,4 +27,4 @@ const Step13 = ({ currentUser }) => (
   <Components.Step step={13} text={text} after={after} currentUser={currentUser}/>
 );
 
-registerComponent('Step13', Step13, withCurrentUser);
+registerComponent({ name: 'Step13', component: Step13, hocs: [withCurrentUser] });

--- a/packages/getting-started/lib/components/steps/Step14.jsx
+++ b/packages/getting-started/lib/components/steps/Step14.jsx
@@ -38,4 +38,4 @@ const Step14 = ({ mutations }) => (
   </Components.Step>
 );
 
-registerComponent('Step14', Step14, withMutationResolvers);
+registerComponent({ name: 'Step14', component: Step14, hocs: [withMutationResolvers] });

--- a/packages/getting-started/lib/components/steps/Step15.jsx
+++ b/packages/getting-started/lib/components/steps/Step15.jsx
@@ -25,4 +25,4 @@ const Step15 = () => (
   <Components.Step step={15} text={text} after={after} />
 );
 
-registerComponent('Step15', Step15);
+registerComponent({ name: 'Step15', component: Step15 });

--- a/packages/getting-started/lib/components/steps/Step16.jsx
+++ b/packages/getting-started/lib/components/steps/Step16.jsx
@@ -37,4 +37,4 @@ const Step16 = () => (
   <Components.Step step={16} text={text} after={after}/>
 );
 
-registerComponent('Step16', Step16);
+registerComponent({ name: 'Step16', component: Step16 });

--- a/packages/getting-started/lib/components/steps/Step17.jsx
+++ b/packages/getting-started/lib/components/steps/Step17.jsx
@@ -37,4 +37,4 @@ const Step17 = () => (
   <Components.Step step={17} text={text} after={after}/>
 );
 
-registerComponent('Step17', Step17);
+registerComponent({ name: 'Step17', component: Step17 });

--- a/packages/getting-started/lib/components/steps/Step18.jsx
+++ b/packages/getting-started/lib/components/steps/Step18.jsx
@@ -35,4 +35,4 @@ const Step18 = () => (
   <Components.Step step={18} text={text} after={after}/>
 );
 
-registerComponent('Step18', Step18);
+registerComponent({ name: 'Step18', component: Step18 });

--- a/packages/getting-started/lib/components/steps/Step19.jsx
+++ b/packages/getting-started/lib/components/steps/Step19.jsx
@@ -27,4 +27,4 @@ const Step19 = () => (
   <Components.Step step={19} text={text} after={after}/>
 );
 
-registerComponent('Step19', Step19);
+registerComponent({ name: 'Step19', component: Step19 });

--- a/packages/getting-started/lib/components/steps/Step2.jsx
+++ b/packages/getting-started/lib/components/steps/Step2.jsx
@@ -23,4 +23,4 @@ You can review them all by accessing the [Components dashboard](/components) (no
 
 const Step2 = () => <Components.Step step={2} text={text} after={after} />;
 
-registerComponent('Step2', Step2);
+registerComponent({ name: 'Step2', component: Step2 });

--- a/packages/getting-started/lib/components/steps/Step20.jsx
+++ b/packages/getting-started/lib/components/steps/Step20.jsx
@@ -39,4 +39,4 @@ const Step20 = () => (
   <Components.Step step={20} text={text} lastStep={true} />
 );
 
-registerComponent('Step20', Step20);
+registerComponent({ name: 'Step20', component: Step20 });

--- a/packages/getting-started/lib/components/steps/Step3.jsx
+++ b/packages/getting-started/lib/components/steps/Step3.jsx
@@ -19,4 +19,4 @@ Now let's learn a couple more Vulcan basics before we start building our little 
 
 const Step3 = () => <Components.Step step={3} text={text} after={after}/>;
 
-// registerComponent({ name: 'Step3', component: Step3}); // uncomment on #Step2
+// registerComponent({ name: 'Step3', component: Step3 }); // uncomment on #Step2

--- a/packages/getting-started/lib/components/steps/Step4.jsx
+++ b/packages/getting-started/lib/components/steps/Step4.jsx
@@ -29,4 +29,4 @@ const Step4 = () => (
   </Components.Step>
 );
 
-registerComponent('Step4', Step4);
+registerComponent({ name: 'Step4', component: Step4 });

--- a/packages/getting-started/lib/components/steps/Step5.jsx
+++ b/packages/getting-started/lib/components/steps/Step5.jsx
@@ -39,4 +39,4 @@ const Step5 = () => (
   </Components.Step>
 );
 
-registerComponent('Step5', Step5);
+registerComponent({ name: 'Step5', component: Step5 });

--- a/packages/getting-started/lib/components/steps/Step6.jsx
+++ b/packages/getting-started/lib/components/steps/Step6.jsx
@@ -39,4 +39,4 @@ const Step6 = () => (
   </Components.Step>
 );
 
-registerComponent('Step6', Step6);
+registerComponent({ name: 'Step6', component: Step6 });

--- a/packages/getting-started/lib/components/steps/Step7.jsx
+++ b/packages/getting-started/lib/components/steps/Step7.jsx
@@ -35,4 +35,4 @@ const Step7 = ({ data }) => (
   </Components.Step>
 );
 
-registerComponent('Step7', Step7, /* withGraphQLSchema */); // uncomment on #Step7
+registerComponent({ name: 'Step7', component: Step7, hocs: [/* withGraphQLSchema */] }); // uncomment on #Step7

--- a/packages/getting-started/lib/components/steps/Step8.jsx
+++ b/packages/getting-started/lib/components/steps/Step8.jsx
@@ -66,4 +66,4 @@ const Step8 = ({ loading, moviesCount }) => (
   </Components.Step>
 );
 
-registerComponent('Step8', Step8, withMoviesCount);
+registerComponent({ name: 'Step8', component: Step8, hocs: [withMoviesCount] });

--- a/packages/getting-started/lib/components/steps/Step9.jsx
+++ b/packages/getting-started/lib/components/steps/Step9.jsx
@@ -52,4 +52,4 @@ const Step9 = ({ resolvers }) => (
   </Components.Step>
 );
 
-registerComponent('Step9', Step9, withQueryResolvers);
+registerComponent({ name: 'Step9', component: Step9, hocs: [withQueryResolvers] });


### PR DESCRIPTION
Call `registerComponent` with object argument instead of rest parameters

Executed following find & replace regex:
* `registerComponent\(('[A-Za-z0-9]*'), ([A-Za-z0-9]*), (.*)\)`
➡ `registerComponent({ name: $1, component: $2, hocs: [$3] })`
* `registerComponent\(('[A-Za-z0-9]*'), ([A-Za-z0-9]*)\)` ➡ `registerComponent({ name: $1, component: $2 })`

Note: This change exacerbates VulcanJS/Vulcan#2061, and probably shouldn't be merged until that issue is resolved.