### PR TITLE
small fixes in example-forum 1.12.3

### DIFF
--- a/packages/example-forum/lib/modules/posts/schema.js
+++ b/packages/example-forum/lib/modules/posts/schema.js
@@ -57,13 +57,13 @@ const schema = {
     canUpdate: ['admins'],
     input: 'datetime',
     group: formGroups.admin,
-    onCreate: ({document: post, currentUser}) => {
+    onCreate: ({newDocument: post, currentUser}) => {
       // Set the post's postedAt if it's going to be approved
       if (!post.postedAt && getCollection('Posts').getDefaultStatus(currentUser) === getCollection('Posts').config.STATUS_APPROVED) {
         return new Date();
       }
     },
-    onUpdate: ({data, post}) => {
+    onUpdate: ({data, document: post}) => {
       // Set the post's postedAt if it's going to be approved
       if (!post.postedAt && data.status === getCollection('Posts').config.STATUS_APPROVED) {
         return new Date();
@@ -111,7 +111,7 @@ const schema = {
     type: String,
     optional: true,
     canRead: ['guests'],
-    onCreate: ({post}) => {
+    onCreate: ({newDocument: post}) => {
       return Utils.slugify(post.title);
     },
     onUpdate: ({data}) => {
@@ -140,7 +140,7 @@ const schema = {
     type: String,
     optional: true,
     canRead: ['guests'],
-    onCreate: ({post}) => {
+    onCreate: ({newDocument: post}) => {
       if (post.body) {
         return Utils.sanitize(marked(post.body));
       }
@@ -159,7 +159,7 @@ const schema = {
     optional: true,
     canRead: ['guests'],
     searchable: true,
-    onCreate: ({post}) => {
+    onCreate: ({newDocument: post}) => {
       if (post.body) {
         // excerpt length is configurable via the settings (30 words by default, ~255 characters)
         const excerptLength = getSetting('forum.postExcerptLength', 30); 
@@ -209,7 +209,7 @@ const schema = {
     canCreate: ['admins'],
     canUpdate: ['admins'],
     input: 'select',
-    onCreate: ({document, currentUser}) => {
+    onCreate: ({newDocument: document, currentUser}) => {
       if (!document.status) {
         return getCollection('Posts').getDefaultStatus(currentUser);
       }
@@ -230,7 +230,7 @@ const schema = {
     type: Boolean,
     optional: true,
     canRead: ['guests'],
-    onCreate: ({post}) => {
+    onCreate: ({newDocument: post}) => {
       // Set the post's isFuture to true if necessary
       if (post.postedAt) {
         const postTime = new Date(post.postedAt).getTime();
@@ -238,7 +238,7 @@ const schema = {
         return postTime > currentTime; // round up to the second
       }
     },
-    onUpdate: ({data, post}) => {
+    onUpdate: ({data, document: post}) => {
       // Set the post's isFuture to true if necessary
       if (data.postedAt) {
         const postTime = new Date(data.postedAt).getTime();
@@ -265,7 +265,7 @@ const schema = {
     canUpdate: ['admins'],
     input: 'checkbox',
     group: formGroups.admin,
-    onCreate: ({post}) => {
+    onCreate: ({newDocument: post}) => {
       if(!post.sticky) {
         return false;
       }


### PR DESCRIPTION
`onCreate: ({document: post, currentUser})` => `onCreate: ({newDocument: post, currentUser})`
`onUpdate: ({data, post})` => `onUpdate: ({data, document: post})`
`onCreate: ({post})` => `onCreate: ({newDocument: post})`
`onCreate: ({document, currentUser})` => `onCreate: ({newDocument: document, currentUser})`
