### PR TITLE
Update permissions : movies.create -> movie.create

### DIFF
--- a/packages/example-movies/lib/modules/movies/mutations.js
+++ b/packages/example-movies/lib/modules/movies/mutations.js
@@ -28,7 +28,7 @@ const mutations = {
 
     check(user) {
       if (!user) return false; //the user must be logged in
-      return Users.canDo(user, 'movies.create'); // the user must have the permission to do the mutation. For this, see permissions.js
+      return Users.canDo(user, 'movie.create'); // the user must have the permission to do the mutation. For this, see permissions.js
     },
 
     mutation(root, args, context) {
@@ -53,8 +53,8 @@ const mutations = {
     check(user, document) {
       if (!user || !document) return false;
       return Users.owns(user, document)
-        ? Users.canDo(user, 'movies.update.own')
-        : Users.canDo(user, `movies.update.all`);
+        ? Users.canDo(user, 'movie.update.own')
+        : Users.canDo(user, `movie.update.all`);
     },
 
     mutation(root, {selector, data}, context) {
@@ -79,8 +79,8 @@ const mutations = {
     check(user, document) {
       if (!user || !document) return false;
       return Users.owns(user, document)
-        ? Users.canDo(user, 'movies.delete.own')
-        : Users.canDo(user, `movies.delete.all`);
+        ? Users.canDo(user, 'movie.delete.own')
+        : Users.canDo(user, `movie.delete.all`);
     },
 
     mutation(root, { selector }, context) {

--- a/packages/example-movies/lib/modules/movies/permissions.js
+++ b/packages/example-movies/lib/modules/movies/permissions.js
@@ -1,14 +1,14 @@
 import Users from 'meteor/vulcan:users';
 
 const membersActions = [
-  'movies.create',
-  'movies.update.own',
-  'movies.delete.own',
+  'movie.create',
+  'movie.update.own',
+  'movie.delete.own',
 ];
 Users.groups.members.can(membersActions);
 
 const adminActions = [
-  'movies.update.all',
-  'movies.delete.all'
+  'movie.update.all',
+  'movie.delete.all'
 ];
 Users.groups.admins.can(adminActions);

--- a/packages/example-movies/lib/server/seed.js
+++ b/packages/example-movies/lib/server/seed.js
@@ -6,7 +6,7 @@ Seed the database with some dummy content.
 
 import { Promise } from 'meteor/promise';
 import Users from 'meteor/vulcan:users';
-import { newMutation } from 'meteor/vulcan:core';
+import { createMutator } from 'meteor/vulcan:core';
 import Movies from '../modules/movies/collection.js';
 
 const seedData = [
@@ -62,7 +62,7 @@ const createUser = async (username, email) => {
     email,
     isDummy: true,
   };
-  return newMutation({
+  return createMutator({
     collection: Users,
     document: user,
     validate: false,
@@ -94,8 +94,8 @@ Meteor.startup(() => {
   if (Movies.find().fetch().length === 0) {
     // eslint-disable-next-line no-console
     console.log('// creating dummy movies');
-    Promise.awaitAll(seedData.map(document => newMutation({
-      action: 'movies.new',
+    Promise.awaitAll(seedData.map(document => createMutator({
+      action: 'movie.create',
       collection: Movies,
       document,
       currentUser,


### PR DESCRIPTION
This was breaking the use of default mutations.
I also updated the name of the mutator used in seed.js: newMutation -> createMutator. I can see that there is an `action: 'movie.create` arg passed to the mutator, however it seems that it is not used in the mutator, so it seems useless from my point of view. Ok to remove @SachaG ?