### PR TITLE
[WIP] Apollo 2: Update Links to react-router v4

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,18 +12,21 @@
   },
   "rules": {
     "babel/generator-star-spacing": 0,
-    "babel/new-cap": [1, {
-      "capIsNewExceptions": [
-        "Optional",
-        "OneOf",
-        "Maybe",
-        "MailChimpAPI",
-        "Juice",
-        "Run",
-        "AppComposer",
-        "Query",
-      ]
-    }],
+    "babel/new-cap": [
+      1,
+      {
+        "capIsNewExceptions": [
+          "Optional",
+          "OneOf",
+          "Maybe",
+          "MailChimpAPI",
+          "Juice",
+          "Run",
+          "AppComposer",
+          "Query"
+        ]
+      }
+    ],
     "babel/array-bracket-spacing": 0,
     "babel/object-curly-spacing": 0,
     "babel/object-shorthand": 0,
@@ -33,15 +36,19 @@
     "key-spacing": 0,
     "no-extra-boolean-cast": 0,
     "no-undef": 1,
-    "no-unused-vars": [1, {
-      "vars": "all",
-      "args": "none",
-      "varsIgnorePattern": "React|PropTypes|Component"
-    }],
+    "no-unused-vars": [
+      1,
+      {
+        "vars": "all",
+        "args": "none",
+        "varsIgnorePattern": "React|PropTypes|Component"
+      }
+    ],
     "no-console": 1,
     "react/prop-types": 0,
     "meteor/audit-argument-checks": 0,
-    "no-case-declarations": 0
+    "no-case-declarations": 0,
+    "quotes": [1, "single"]
   },
   "env": {
     "browser": true,
@@ -50,11 +57,7 @@
     "meteor": true,
     "node": true
   },
-  "plugins": [
-    "babel",
-    "meteor",
-    "react"
-  ],
+  "plugins": ["babel", "meteor", "react"],
   "settings": {
     "import/resolver": "meteor"
   },

--- a/.meteor/packages
+++ b/.meteor/packages
@@ -26,3 +26,4 @@ getting-started
 # example-interfaces
 # example-reactions
 # example-forms
+tmeasday:check-npm-versions

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,21 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@apollographql/apollo-upload-server": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@apollographql/apollo-upload-server/-/apollo-upload-server-5.0.3.tgz",
+      "integrity": "sha512-tGAp3ULNyoA8b5o9LsU2Lq6SwgVPUOKAqKywu2liEtTvrFSGPrObwanhYwArq3GPeOqp2bi+JknSJCIU3oQN1Q==",
+      "requires": {
+        "@babel/runtime-corejs2": "^7.0.0-rc.1",
+        "busboy": "^0.2.14",
+        "object-path": "^0.11.4"
+      }
+    },
+    "@apollographql/graphql-playground-html": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.0.tgz",
+      "integrity": "sha512-QAZIFrfVRkjvMkUHIQKZXZ3La0V5t12w5PWrhihYEabHwzIZV/txQd/kSYHgYPXC4s5OURxsXZop9f0BzI2QIQ=="
+    },
     "@babel/runtime": {
       "version": "7.0.0-beta.46",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-beta.46.tgz",
@@ -12,6 +27,81 @@
         "core-js": "^2.5.3",
         "regenerator-runtime": "^0.11.1"
       }
+    },
+    "@babel/runtime-corejs2": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.0.0.tgz",
+      "integrity": "sha512-Yww0jXgolNtkhcK+Txo5JN+DjBpNmmAtD7G99HOebhEjBzjnACG09Tip9C8lSOF6PrhA56OeJWeOZduNJaKxBA==",
+      "requires": {
+        "core-js": "^2.5.7",
+        "regenerator-runtime": "^0.12.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.5.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+        },
+        "regenerator-runtime": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+        }
+      }
+    },
+    "@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+    },
+    "@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+    },
+    "@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+    },
+    "@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+    },
+    "@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+    },
+    "@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+    },
+    "@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@segment/loosely-validate-event": {
       "version": "1.1.2",
@@ -22,11 +112,69 @@
         "join-component": "^1.1.0"
       }
     },
+    "@types/accepts": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.5.tgz",
+      "integrity": "sha512-jOdnI/3qTpHABjM5cx1Hc0sKsPoYCp+DP/GJRGtDlPd7fiV9oXGGIcjW/ZOxLIvjGz8MA+uMZI9metHlgqbgwQ==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/async": {
       "version": "2.0.49",
       "resolved": "https://registry.npmjs.org/@types/async/-/async-2.0.49.tgz",
       "integrity": "sha512-Benr3i5odUkvpFkOpzGqrltGdbSs+EVCkEBGXbuR7uT0VzhXKIkhem6PDzHdx5EonA+rfbB3QvP6aDOw5+zp5Q==",
       "optional": true
+    },
+    "@types/body-parser": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.0.tgz",
+      "integrity": "sha512-a2+YeUjPkztKJu5aIF2yArYFQQp8d51wZ7DavSHjFuY1mqVgidGyzEQ41JIVNy82fXj8yPgy2vJmfIywgESW6w==",
+      "requires": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/connect": {
+      "version": "3.4.32",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.32.tgz",
+      "integrity": "sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/cors": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.4.tgz",
+      "integrity": "sha512-ipZjBVsm2tF/n8qFGOuGBkUij9X9ZswVi9G3bx/6dz7POpVa6gVHcj1wsX/LVEn9MMF41fxK/PnZPPoTD1UFPw==",
+      "requires": {
+        "@types/express": "*"
+      }
+    },
+    "@types/events": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
+      "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA=="
+    },
+    "@types/express": {
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.16.0.tgz",
+      "integrity": "sha512-TtPEYumsmSTtTetAPXlJVf3kEqb6wZK0bZojpJQrnD/djV4q1oB6QQ8aKvKqwNPACoe02GNiy5zDzcYivR5Z2w==",
+      "requires": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "@types/express-serve-static-core": {
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.0.tgz",
+      "integrity": "sha512-lTeoCu5NxJU4OD9moCgm0ESZzweAx0YqsAcab6OB0EB3+As1OaHtKnaGJvcngQxYsi9UNv0abn4/DRavrRxt4w==",
+      "requires": {
+        "@types/events": "*",
+        "@types/node": "*",
+        "@types/range-parser": "*"
+      }
     },
     "@types/graphql": {
       "version": "0.10.2",
@@ -34,10 +182,43 @@
       "integrity": "sha512-Ayw0w+kr8vYd8DToiMXjcHxXv1ljWbqX2mnLwXDxkBgog3vywGriC0JZ+npsuohKs3+E88M8OOtobo4g0X3SIA==",
       "optional": true
     },
+    "@types/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q=="
+    },
+    "@types/mime": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.0.tgz",
+      "integrity": "sha512-A2TAGbTFdBw9azHbpVd+/FkdW2T6msN1uct1O9bH3vTerEHKZhTXJUQXy+hNq1B0RagfU8U+KBdqiZpxjhOUQA=="
+    },
     "@types/node": {
       "version": "9.6.32",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.32.tgz",
       "integrity": "sha512-5+L3wQ+FHoQ589EaH6rYICleuj8gnunq+1CJkM9fxklirErIOv+kxm3s/vecYnpJOYnFowE5uUizcb3hgjHUug=="
+    },
+    "@types/range-parser": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.2.tgz",
+      "integrity": "sha512-HtKGu+qG1NPvYe1z7ezLsyIaXYyi8SoAVqWDZgDQ8dLrsZvSzUNCwZyfX33uhWxL/SU0ZDQZ3nwZ0nimt507Kw=="
+    },
+    "@types/serve-static": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.2.tgz",
+      "integrity": "sha512-/BZ4QRLpH/bNYgZgwhKEh+5AsboDBcUdlBYgzoLX0fpj3Y2gp6EApyOlM3bK53wQS/OE1SrdSYBAbux2D1528Q==",
+      "requires": {
+        "@types/express-serve-static-core": "*",
+        "@types/mime": "*"
+      }
+    },
+    "@types/ws": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-5.1.2.tgz",
+      "integrity": "sha512-NkTXUKTYdXdnPE2aUUbGOXE1XfMK527SCvU/9bj86kyFF6kZ9ZnOQ3mK5jADn98Y2vEUD/7wKDgZa7Qst2wYOg==",
+      "requires": {
+        "@types/events": "*",
+        "@types/node": "*"
+      }
     },
     "@types/zen-observable": {
       "version": "0.8.0",
@@ -275,6 +456,15 @@
         }
       }
     },
+    "apollo-datasource": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-0.1.3.tgz",
+      "integrity": "sha512-yEGEe5Cjzqqu5ml1VV3O8+C+thzdknZri9Ny0P3daTGNO+45J3vBOMcmaANeeI2+OOeWxdqUNa5aPOx/35kniw==",
+      "requires": {
+        "apollo-server-caching": "0.1.2",
+        "apollo-server-env": "2.0.3"
+      }
+    },
     "apollo-engine": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/apollo-engine/-/apollo-engine-0.5.6.tgz",
@@ -304,6 +494,36 @@
       "resolved": "https://registry.npmjs.org/apollo-engine-binary-windows/-/apollo-engine-binary-windows-0.2017.11-84-gb299b9188.tgz",
       "integrity": "sha512-ecpP1HrlP+eb5mNQuz7ObzMWtGJA78UrPlzGRes1KiKJ/c8e1UrrAWI/wuI0Ry7fIKYA6dUzxJ4fHR5TEnMAVA==",
       "optional": true
+    },
+    "apollo-engine-reporting": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/apollo-engine-reporting/-/apollo-engine-reporting-0.0.6.tgz",
+      "integrity": "sha512-JmfNJ9v3QEJQ8ZhLfCKEDiww53n5kj5HarP85p8LreoYNojbvcWN8Qm6RgvSG5N/ZJrAYHeTRQbSxm1vWwGubw==",
+      "requires": {
+        "apollo-engine-reporting-protobuf": "^0.0.1",
+        "apollo-server-env": "^2.0.3",
+        "async-retry": "^1.2.1",
+        "graphql-extensions": "^0.2.1",
+        "lodash": "^4.17.10"
+      },
+      "dependencies": {
+        "graphql-extensions": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.2.1.tgz",
+          "integrity": "sha512-/1FTPSWSffDjlRyMAV2UwQhojLmca9aQD0ieo1IYiqT5SE+uOWi4r83QF1CoER0sREIsH3s+nTmdH3cvQVG3MA==",
+          "requires": {
+            "apollo-server-env": "^2.0.3"
+          }
+        }
+      }
+    },
+    "apollo-engine-reporting-protobuf": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/apollo-engine-reporting-protobuf/-/apollo-engine-reporting-protobuf-0.0.1.tgz",
+      "integrity": "sha512-AySoDgog2p1Nph44FyyqaU4AfRZOXx8XZxRsVHvYY4dHlrMmDDhhjfF3Jswa7Wr8X/ivvx3xA0jimRn6rsG8Ew==",
+      "requires": {
+        "protobufjs": "^6.8.6"
+      }
     },
     "apollo-errors": {
       "version": "1.9.0",
@@ -415,6 +635,200 @@
         "apollo-utilities": "^1.0.0"
       }
     },
+    "apollo-server": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/apollo-server/-/apollo-server-2.1.0.tgz",
+      "integrity": "sha512-Uo5RFHGtUPq3OvycLXCll5QgXf2wNVBFYUhapByADBP4E1KRgbyl9Fbf82OgcbbLYwEZTlQMbyBpd6hX8XJKAw==",
+      "requires": {
+        "apollo-server-core": "^2.1.0",
+        "apollo-server-express": "^2.1.0",
+        "express": "^4.0.0",
+        "graphql-subscriptions": "^0.5.8",
+        "graphql-tools": "^3.0.4"
+      },
+      "dependencies": {
+        "apollo-cache-control": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.2.5.tgz",
+          "integrity": "sha512-xEDrUvo3U2mQKSzA8NzQmgeqK4ytwFnTGl2YKGKPfG0+r8fZdswKp6CDBue29KLO8KkSuqW/hntveWrAdK51FQ==",
+          "requires": {
+            "apollo-server-env": "^2.0.3",
+            "graphql-extensions": "^0.2.1"
+          }
+        },
+        "apollo-server-core": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.1.0.tgz",
+          "integrity": "sha512-D1Tw0o3NzCQ2KGM8EWh9AHELHmn/SE361dtlqJxkbelxXqAkCIGIFywF30h+0ezhMbgbO7eqBBJfvRilF/oJHA==",
+          "requires": {
+            "@apollographql/apollo-upload-server": "^5.0.3",
+            "@types/ws": "^5.1.2",
+            "apollo-cache-control": "^0.2.5",
+            "apollo-datasource": "^0.1.3",
+            "apollo-engine-reporting": "^0.0.6",
+            "apollo-server-caching": "^0.1.2",
+            "apollo-server-env": "^2.0.3",
+            "apollo-server-errors": "^2.0.2",
+            "apollo-tracing": "^0.2.5",
+            "graphql-extensions": "^0.2.1",
+            "graphql-subscriptions": "^0.5.8",
+            "graphql-tag": "^2.9.2",
+            "graphql-tools": "^3.0.4",
+            "hash.js": "^1.1.3",
+            "lodash": "^4.17.10",
+            "subscriptions-transport-ws": "^0.9.11",
+            "ws": "^5.2.0"
+          }
+        },
+        "apollo-server-express": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.1.0.tgz",
+          "integrity": "sha512-jLFIz1VLduMA/rme4OAy3IPeoaMEZOPoQXpio8AhfjIqCijRPPfoWJ2QMqz56C/g3vas7rZtgcVOrHpjBKudjw==",
+          "requires": {
+            "@apollographql/apollo-upload-server": "^5.0.3",
+            "@apollographql/graphql-playground-html": "^1.6.0",
+            "@types/accepts": "^1.3.5",
+            "@types/body-parser": "1.17.0",
+            "@types/cors": "^2.8.4",
+            "@types/express": "4.16.0",
+            "accepts": "^1.3.5",
+            "apollo-server-core": "^2.1.0",
+            "body-parser": "^1.18.3",
+            "cors": "^2.8.4",
+            "graphql-subscriptions": "^0.5.8",
+            "graphql-tools": "^3.0.4",
+            "type-is": "^1.6.16"
+          }
+        },
+        "apollo-tracing": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.2.5.tgz",
+          "integrity": "sha512-DZO7pfL5LATHeJdVFoTZ/N3HwA+IMf1YnIt5K+uMQW+/MrRgYOtTszUv5tYX2cUIqHYHcbdDaBQUuIXwSpaV2Q==",
+          "requires": {
+            "apollo-server-env": "^2.0.3",
+            "graphql-extensions": "^0.2.1"
+          }
+        },
+        "body-parser": {
+          "version": "1.18.3",
+          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
+          "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
+          "requires": {
+            "bytes": "3.0.0",
+            "content-type": "~1.0.4",
+            "debug": "2.6.9",
+            "depd": "~1.1.2",
+            "http-errors": "~1.6.3",
+            "iconv-lite": "0.4.23",
+            "on-finished": "~2.3.0",
+            "qs": "6.5.2",
+            "raw-body": "2.3.3",
+            "type-is": "~1.6.16"
+          }
+        },
+        "graphql-extensions": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.2.1.tgz",
+          "integrity": "sha512-/1FTPSWSffDjlRyMAV2UwQhojLmca9aQD0ieo1IYiqT5SE+uOWi4r83QF1CoER0sREIsH3s+nTmdH3cvQVG3MA==",
+          "requires": {
+            "apollo-server-env": "^2.0.3"
+          }
+        },
+        "graphql-tools": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-3.1.1.tgz",
+          "integrity": "sha512-yHvPkweUB0+Q/GWH5wIG60bpt8CTwBklCSzQdEHmRUgAdEQKxw+9B7zB3dG7wB3Ym7M7lfrS4Ej+jtDZfA2UXg==",
+          "requires": {
+            "apollo-link": "^1.2.2",
+            "apollo-utilities": "^1.0.1",
+            "deprecated-decorator": "^0.1.6",
+            "iterall": "^1.1.3",
+            "uuid": "^3.1.0"
+          }
+        },
+        "http-errors": {
+          "version": "1.6.3",
+          "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+          "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.1.0",
+            "statuses": ">= 1.4.0 < 2"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.23",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+          "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "mime-db": {
+          "version": "1.36.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
+          "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw=="
+        },
+        "mime-types": {
+          "version": "2.1.20",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
+          "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
+          "requires": {
+            "mime-db": "~1.36.0"
+          }
+        },
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+        },
+        "raw-body": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
+          "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
+          "requires": {
+            "bytes": "3.0.0",
+            "http-errors": "1.6.3",
+            "iconv-lite": "0.4.23",
+            "unpipe": "1.0.0"
+          }
+        },
+        "setprototypeof": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+        },
+        "type-is": {
+          "version": "1.6.16",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+          "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+          "requires": {
+            "media-typer": "0.3.0",
+            "mime-types": "~2.1.18"
+          }
+        }
+      }
+    },
+    "apollo-server-caching": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.1.2.tgz",
+      "integrity": "sha512-jBRnsTgXN0m8yVpumoelaUq9mXR7YpJ3EE+y/alI7zgXY+0qFDqksRApU8dEfg3q6qUnO7rFxRhdG5eyc0+1ig==",
+      "requires": {
+        "lru-cache": "^4.1.3"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+          "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        }
+      }
+    },
     "apollo-server-core": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-1.4.0.tgz",
@@ -424,6 +838,27 @@
         "apollo-tracing": "^0.1.0",
         "graphql-extensions": "^0.0.x"
       }
+    },
+    "apollo-server-env": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-2.0.3.tgz",
+      "integrity": "sha512-uIfKFH8n8xKO0eLb9Fa79+s2DdMuVethgznvW6SrOYq5VzgkIIobqKEuZPKa5wObw9CkCyju/+Sr7b7WWMFxUQ==",
+      "requires": {
+        "node-fetch": "^2.1.2",
+        "util.promisify": "^1.0.0"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.2.0.tgz",
+          "integrity": "sha512-OayFWziIxiHY8bCUyLX6sTpDH8Jsbp4FfYd1j1f7vZyfgkcOnAyM4oQR16f8a0s7Gl/viMGRey8eScYk4V4EZA=="
+        }
+      }
+    },
+    "apollo-server-errors": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.0.2.tgz",
+      "integrity": "sha512-zyWDqAVDCkj9espVsoUpZr9PwDznM8UW6fBfhV+i1br//s2AQb07N6ektZ9pRIEvkhykDZW+8tQbDwAO0vUROg=="
     },
     "apollo-server-express": {
       "version": "1.4.0",
@@ -539,6 +974,19 @@
       "version": "0.2.10",
       "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
       "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
+    },
+    "async-limiter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+    },
+    "async-retry": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.2.3.tgz",
+      "integrity": "sha512-tfDb02Th6CE6pJUF2gjW5ZVjsgwlucVXOEQMvEX9JgSJMs9gAX+Nz3xRuJBKuUYjTSYORqvDBORdAQ3LU59g7Q==",
+      "requires": {
+        "retry": "0.12.0"
+      }
     },
     "asynckit": {
       "version": "0.4.0",
@@ -852,6 +1300,11 @@
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
       "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
       "dev": true
+    },
+    "backo2": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
     },
     "bail": {
       "version": "1.0.2",
@@ -1378,6 +1831,38 @@
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
+    "busboy": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.2.14.tgz",
+      "integrity": "sha1-bCpiLvz0fFe7vh4qnDetNseSVFM=",
+      "requires": {
+        "dicer": "0.2.5",
+        "readable-stream": "1.1.x"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
@@ -1740,6 +2225,15 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "cors": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.4.tgz",
+      "integrity": "sha1-K9OB8usgECAQXNUOpZ2mMJBpRoY=",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
+    },
     "create-react-class": {
       "version": "15.6.2",
       "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.2.tgz",
@@ -1955,6 +2449,38 @@
       "dev": true,
       "requires": {
         "repeating": "^2.0.0"
+      }
+    },
+    "dicer": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
+      "integrity": "sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=",
+      "requires": {
+        "readable-stream": "1.1.x",
+        "streamsearch": "0.1.2"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
       }
     },
     "doctrine": {
@@ -2643,6 +3169,11 @@
         }
       }
     },
+    "eventemitter3": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
+      "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA=="
+    },
     "exenv": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
@@ -3023,6 +3554,21 @@
         "source-map-support": "^0.5.1"
       }
     },
+    "graphql-subscriptions": {
+      "version": "0.5.8",
+      "resolved": "http://registry.npmjs.org/graphql-subscriptions/-/graphql-subscriptions-0.5.8.tgz",
+      "integrity": "sha512-0CaZnXKBw2pwnIbvmVckby5Ge5e2ecmjofhYCdyeACbCly2j3WXDP/pl+s+Dqd2GQFC7y99NB+53jrt55CKxYQ==",
+      "requires": {
+        "iterall": "^1.2.1"
+      },
+      "dependencies": {
+        "iterall": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.2.2.tgz",
+          "integrity": "sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA=="
+        }
+      }
+    },
     "graphql-tag": {
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.9.2.tgz",
@@ -3131,6 +3677,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
       "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
+    },
+    "hash.js": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.5.tgz",
+      "integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
     },
     "hast-util-parse-selector": {
       "version": "2.1.0",
@@ -4134,6 +4689,11 @@
       "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
       "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw="
     },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
@@ -4901,6 +5461,11 @@
       "resolved": "https://registry.npmjs.org/mingo/-/mingo-0.8.1.tgz",
       "integrity": "sha1-fnb7YEITpMy5T8UQE1VDQwHur2o="
     },
+    "minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -5046,6 +5611,11 @@
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
       "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
     },
+    "object-path": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.4.tgz",
+      "integrity": "sha1-NwrnUvvzfePqcKhhwju6iRVpGUk="
+    },
     "object.assign": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
@@ -5055,6 +5625,15 @@
         "function-bind": "^1.1.1",
         "has-symbols": "^1.0.0",
         "object-keys": "^1.0.11"
+      }
+    },
+    "object.getownpropertydescriptors": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.1"
       }
     },
     "object.values": {
@@ -5437,6 +6016,33 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-3.2.0.tgz",
       "integrity": "sha1-/RSDyPusYYCPX+NZ52k6H0ilgzE="
+    },
+    "protobufjs": {
+      "version": "6.8.8",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.8.tgz",
+      "integrity": "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==",
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.0",
+        "@types/node": "^10.1.0",
+        "long": "^4.0.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.11.0",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.11.0.tgz",
+          "integrity": "sha512-R4Dvw6KjSYn/SpvjRchBOwXr14vVVcFXCtnM3f0aLvlJS8a599rrcEoihcP2/+Z/f75E5GNPd4aWM7j1yei9og=="
+        }
+      }
     },
     "proxy-addr": {
       "version": "2.0.3",
@@ -5865,30 +6471,12 @@
             }
           }
         },
-        "hoist-non-react-statics": {
-          "version": "2.5.5",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
-        },
         "invariant": {
           "version": "2.2.4",
           "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
           "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
           "requires": {
             "loose-envify": "^1.0.0"
-          }
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "path-to-regexp": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
-          "requires": {
-            "isarray": "0.0.1"
           }
         },
         "prop-types": {
@@ -5898,20 +6486,6 @@
           "requires": {
             "loose-envify": "^1.3.1",
             "object-assign": "^4.1.1"
-          }
-        },
-        "react-router": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.3.1.tgz",
-          "integrity": "sha512-yrvL8AogDh2X42Dt9iknk4wF4V8bWREPirFfS9gLU1huk6qK41sg7Z/1S81jjTrGHxa3B8R3J6xIkDAA6CVarg==",
-          "requires": {
-            "history": "^4.7.2",
-            "hoist-non-react-statics": "^2.5.0",
-            "invariant": "^2.2.4",
-            "loose-envify": "^1.3.1",
-            "path-to-regexp": "^1.7.0",
-            "prop-types": "^15.6.1",
-            "warning": "^4.0.1"
           }
         },
         "warning": {
@@ -6219,6 +6793,11 @@
         "exit-hook": "^1.0.0",
         "onetime": "^1.0.0"
       }
+    },
+    "retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
     },
     "right-align": {
       "version": "0.1.3",
@@ -6752,6 +7331,11 @@
         "async": "~0.2.10"
       }
     },
+    "streamsearch": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
+    },
     "strict-uri-encode": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
@@ -6854,6 +7438,25 @@
       "version": "3.4.8",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.4.8.tgz",
       "integrity": "sha512-RVhA1z8dOpHP3hr5B//LrGQzh9sz6Merg4GuOJQu8ZxHP9GmR+cDE6LHkL6l76ASY8pfnsWa1ycjZKjSN2NvLA=="
+    },
+    "subscriptions-transport-ws": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.15.tgz",
+      "integrity": "sha512-f9eBfWdHsePQV67QIX+VRhf++dn1adyC/PZHP6XI5AfKnZ4n0FW+v5omxwdHVpd4xq2ZijaHEcmlQrhBY79ZWQ==",
+      "requires": {
+        "backo2": "^1.0.2",
+        "eventemitter3": "^3.1.0",
+        "iterall": "^1.2.1",
+        "symbol-observable": "^1.0.4",
+        "ws": "^5.2.0"
+      },
+      "dependencies": {
+        "iterall": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.2.2.tgz",
+          "integrity": "sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA=="
+        }
+      }
     },
     "superagent": {
       "version": "3.8.2",
@@ -7334,6 +7937,15 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
+    "util.promisify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+      "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+      "requires": {
+        "define-properties": "^1.1.2",
+        "object.getownpropertydescriptors": "^2.0.3"
+      }
+    },
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -7491,6 +8103,14 @@
       "dev": true,
       "requires": {
         "mkdirp": "^0.5.1"
+      }
+    },
+    "ws": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+      "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+      "requires": {
+        "async-limiter": "~1.0.0"
       }
     },
     "x-is-function": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "apollo-link-error": "^1.1.1",
     "apollo-link-http": "^1.5.5",
     "apollo-link-watched-mutation": "^0.1.0",
+    "apollo-server": "^2.1.0",
     "apollo-server-express": "^1.4.0",
     "babel-runtime": "^6.26.0",
     "bcrypt": "^3.0.0",

--- a/packages/example-customization/lib/components/CustomLogo.jsx
+++ b/packages/example-customization/lib/components/CustomLogo.jsx
@@ -5,17 +5,25 @@ it the same way.
 */
 
 import React from 'react';
-import { IndexLink } from 'react-router';
+import { NavLink } from 'react-router-dom';
 import Users from 'meteor/vulcan:users';
 import { replaceComponent } from 'meteor/vulcan:core';
 
-const CustomLogo = ({logoUrl, siteTitle, currentUser}) => {
+const CustomLogo = ({ logoUrl, siteTitle, currentUser }) => {
   return (
     <div>
-      <h1 className="logo-text"><IndexLink to="/">⭐{siteTitle}⭐</IndexLink></h1>
-      { currentUser ? <span className="logo-hello">Welcome {Users.getDisplayName(currentUser)} 👋</span> : null}
+      <h1 className="logo-text">
+        <NavLink exact to="/">
+          ⭐{siteTitle}⭐
+        </NavLink>
+      </h1>
+      {currentUser ? (
+        <span className="logo-hello">
+          Welcome {Users.getDisplayName(currentUser)} 👋
+        </span>
+      ) : null}
     </div>
-  )
-}
+  );
+};
 
 replaceComponent('Logo', CustomLogo);

--- a/packages/example-customization/lib/components/CustomPostsItem.jsx
+++ b/packages/example-customization/lib/components/CustomPostsItem.jsx
@@ -1,64 +1,91 @@
-import { Components, getRawComponent, replaceComponent } from 'meteor/vulcan:core';
+import {
+  Components,
+  getRawComponent,
+  replaceComponent
+} from 'meteor/vulcan:core';
 import React from 'react';
 import { FormattedMessage } from 'meteor/vulcan:i18n';
-import { Link } from 'react-router';
+import { Link } from 'react-router-dom';
 import { Posts } from 'meteor/example-forum';
 import moment from 'moment';
 
 class CustomPostsItem extends getRawComponent('PostsItem') {
-
   render() {
-
     const post = this.props.post;
 
-    let postClass = "posts-item";
-    if (post.sticky) postClass += " posts-sticky";
+    let postClass = 'posts-item';
+    if (post.sticky) postClass += ' posts-sticky';
 
     // ⭐ custom code starts here ⭐
     if (post.color) {
-      postClass += " post-"+post.color;
+      postClass += ' post-' + post.color;
     }
     // ⭐ custom code ends here ⭐
 
     return (
       <div className={postClass}>
-
         <div className="posts-item-vote">
-          <Components.Vote collection={Posts} document={post} currentUser={this.props.currentUser}/>
+          <Components.Vote
+            collection={Posts}
+            document={post}
+            currentUser={this.props.currentUser}
+          />
         </div>
 
-        {post.thumbnailUrl ? <Components.PostsThumbnail post={post}/> : null}
+        {post.thumbnailUrl ? <Components.PostsThumbnail post={post} /> : null}
 
         <div className="posts-item-content">
-
           <h3 className="posts-item-title">
-            <Link to={Posts.getLink(post)} className="posts-item-title-link" target={Posts.getLinkTarget(post)}>
+            <Link
+              to={Posts.getLink(post)}
+              className="posts-item-title-link"
+              target={Posts.getLinkTarget(post)}
+            >
               {post.title}
             </Link>
             {this.renderCategories()}
           </h3>
 
           <div className="posts-item-meta">
-            {post.user? <div className="posts-item-user"><Components.UsersAvatar user={post.user} size="small"/><Components.UsersName user={post.user}/></div> : null}
-            <div className="posts-item-date">{post.postedAt ? moment(new Date(post.postedAt)).fromNow() : <FormattedMessage id="posts.dateNotDefined"/>}</div>
+            {post.user ? (
+              <div className="posts-item-user">
+                <Components.UsersAvatar user={post.user} size="small" />
+                <Components.UsersName user={post.user} />
+              </div>
+            ) : null}
+            <div className="posts-item-date">
+              {post.postedAt ? (
+                moment(new Date(post.postedAt)).fromNow()
+              ) : (
+                <FormattedMessage id="posts.dateNotDefined" />
+              )}
+            </div>
             <div className="posts-item-comments">
               <Link to={Posts.getPageUrl(post)}>
-                {!post.commentCount || post.commentCount === 0 ? <FormattedMessage id="comments.count_0"/> : 
-                  post.commentCount === 1 ? <FormattedMessage id="comments.count_1" /> :
-                    <FormattedMessage id="comments.count_2" values={{count: post.commentCount}}/>
-                }              
+                {!post.commentCount || post.commentCount === 0 ? (
+                  <FormattedMessage id="comments.count_0" />
+                ) : post.commentCount === 1 ? (
+                  <FormattedMessage id="comments.count_1" />
+                ) : (
+                  <FormattedMessage
+                    id="comments.count_2"
+                    values={{ count: post.commentCount }}
+                  />
+                )}
               </Link>
             </div>
-            {this.props.currentUser && this.props.currentUser.isAdmin ? <Components.PostsStats post={post} /> : null}
-            {Posts.options.mutations.edit.check(this.props.currentUser, post) ? this.renderActions() : null}
+            {this.props.currentUser && this.props.currentUser.isAdmin ? (
+              <Components.PostsStats post={post} />
+            ) : null}
+            {Posts.options.mutations.edit.check(this.props.currentUser, post)
+              ? this.renderActions()
+              : null}
           </div>
-
         </div>
 
         {this.renderCommenters()}
-
       </div>
-    )
+    );
   }
 }
 

--- a/packages/example-forum/lib/components/admin/AdminUsersPosts.js
+++ b/packages/example-forum/lib/components/admin/AdminUsersPosts.js
@@ -1,12 +1,16 @@
 import React from 'react';
 import { Posts } from '../../modules/posts/index.js';
-import { Link } from 'react-router';
+import { Link } from 'react-router-dom';
 
-const AdminUsersPosts = ({ document: user }) => 
+const AdminUsersPosts = ({ document: user }) => (
   <ul>
-    {user.posts && user.posts.map(post => 
-      <li key={post._id}><Link to={Posts.getLink(post)}>{post.title}</Link></li>
-    )}
+    {user.posts &&
+      user.posts.map(post => (
+        <li key={post._id}>
+          <Link to={Posts.getLink(post)}>{post.title}</Link>
+        </li>
+      ))}
   </ul>
+);
 
 export default AdminUsersPosts;

--- a/packages/example-forum/lib/components/common/Logo.jsx
+++ b/packages/example-forum/lib/components/common/Logo.jsx
@@ -1,25 +1,27 @@
 import { registerComponent } from 'meteor/vulcan:core';
 import React from 'react';
-import { IndexLink } from 'react-router';
+import { NavLink } from 'react-router-dom';
 
-const Logo = ({logoUrl, siteTitle}) => {
+const Logo = ({ logoUrl, siteTitle }) => {
   if (logoUrl) {
     return (
       <h1 className="logo-image ">
-        <IndexLink to={{pathname: "/"}}>
+        <IndexLink to={{ pathname: '/' }}>
           <img src={logoUrl} alt={siteTitle} />
         </IndexLink>
       </h1>
-    )
+    );
   } else {
     return (
       <h1 className="logo-text">
-        <IndexLink to={{pathname: "/"}}>{siteTitle}</IndexLink>
+        <NavLink exact to={{ pathname: '/' }}>
+          {siteTitle}
+        </NavLink>
       </h1>
-    )
+    );
   }
-}
+};
 
-Logo.displayName = "Logo";
+Logo.displayName = 'Logo';
 
 registerComponent({ name: 'Logo', component: Logo });

--- a/packages/example-forum/lib/components/common/SearchForm.jsx
+++ b/packages/example-forum/lib/components/common/SearchForm.jsx
@@ -4,28 +4,28 @@ import PropTypes from 'prop-types';
 import { intlShape } from 'meteor/vulcan:i18n';
 import Formsy from 'formsy-react';
 import FRC from 'formsy-react-components';
-import { withRouter, Link } from 'react-router'
+import { withRouter } from 'react-router';
+import { Link } from 'react-router-dom';
 
 const Input = FRC.Input;
 
 // see: http://stackoverflow.com/questions/1909441/jquery-keyup-delay
-const delay = (function(){
+const delay = (function() {
   var timer = 0;
-  return function(callback, ms){
-    clearTimeout (timer);
+  return function(callback, ms) {
+    clearTimeout(timer);
     timer = setTimeout(callback, ms);
   };
 })();
 
-class SearchForm extends Component{
-
+class SearchForm extends Component {
   constructor(props) {
     super(props);
     this.search = this.search.bind(this);
     this.state = {
       pathname: props.router.location.pathname,
       search: props.router.location.query.query || ''
-    }
+    };
   }
 
   // note: why do we need this?
@@ -36,24 +36,27 @@ class SearchForm extends Component{
   }
 
   search(data) {
-
     const router = this.props.router;
     const routerQuery = _.clone(router.location.query);
     delete routerQuery.query;
 
-    const query = data.searchQuery === '' ? routerQuery : {...routerQuery, query: data.searchQuery};
+    const query =
+      data.searchQuery === ''
+        ? routerQuery
+        : { ...routerQuery, query: data.searchQuery };
 
     delay(() => {
       // only update the route if the path hasn't changed in the meantime
       if (this.state.pathname === router.location.pathname) {
-        router.push({pathname: Utils.getRoutePath('posts.list'), query: query});
+        router.push({
+          pathname: Utils.getRoutePath('posts.list'),
+          query: query
+        });
       }
-    }, 700 );
-
+    }, 700);
   }
 
   render() {
-
     const resetQuery = _.clone(this.props.location.query);
     delete resetQuery.query;
 
@@ -63,14 +66,23 @@ class SearchForm extends Component{
           <Input
             name="searchQuery"
             value={this.state.search}
-            placeholder={this.context.intl.formatMessage({id: "posts.search"})}
+            placeholder={this.context.intl.formatMessage({
+              id: 'posts.search'
+            })}
             type="text"
             layout="elementOnly"
           />
-          {this.state.search !== '' ? <Link className="search-form-reset" to={{pathname: '/', query: resetQuery}}><Components.Icon name="close" /></Link> : null}
+          {this.state.search !== '' ? (
+            <Link
+              className="search-form-reset"
+              to={{ pathname: '/', query: resetQuery }}
+            >
+              <Components.Icon name="close" />
+            </Link>
+          ) : null}
         </Formsy.Form>
       </div>
-    )
+    );
   }
 }
 
@@ -78,4 +90,8 @@ SearchForm.contextTypes = {
   intl: intlShape
 };
 
-registerComponent({ name: 'SearchForm', component: SearchForm, hocs: [withRouter] });
+registerComponent({
+  name: 'SearchForm',
+  component: SearchForm,
+  hocs: [withRouter]
+});

--- a/packages/example-forum/lib/components/posts/PostsCategories.jsx
+++ b/packages/example-forum/lib/components/posts/PostsCategories.jsx
@@ -1,17 +1,23 @@
 import { registerComponent } from 'meteor/vulcan:core';
 import React from 'react';
-import { Link } from 'react-router';
+import { Link } from 'react-router-dom';
 
-const PostsCategories = ({post}) => {
+const PostsCategories = ({ post }) => {
   return (
     <div className="posts-categories">
-      {post.categories.map(category => 
-        <Link className="posts-category" key={category._id} to={{pathname: "/", query: {cat: category.slug}}}>{category.name}</Link>
-      )}
+      {post.categories.map(category => (
+        <Link
+          className="posts-category"
+          key={category._id}
+          to={{ pathname: '/', query: { cat: category.slug } }}
+        >
+          {category.name}
+        </Link>
+      ))}
     </div>
-  )
+  );
 };
 
-PostsCategories.displayName = "PostsCategories";
+PostsCategories.displayName = 'PostsCategories';
 
 registerComponent({ name: 'PostsCategories', component: PostsCategories });

--- a/packages/example-forum/lib/components/posts/PostsCommenters.jsx
+++ b/packages/example-forum/lib/components/posts/PostsCommenters.jsx
@@ -1,18 +1,22 @@
 import { Components, registerComponent } from 'meteor/vulcan:core';
 import React from 'react';
-import { Link } from 'react-router';
+import { Link } from 'react-router-dom';
 import { Posts } from '../../modules/posts/index.js';
 
-const PostsCommenters = ({post}) => {
+const PostsCommenters = ({ post }) => {
   return (
     <div className="posts-commenters">
       <div className="posts-commenters-avatars">
-        {_.take(post.commenters, 4).map(user => user && <Components.UsersAvatar key={user._id} user={user}/>)}
+        {_.take(post.commenters, 4).map(
+          user => user && <Components.UsersAvatar key={user._id} user={user} />
+        )}
       </div>
       <div className="posts-commenters-discuss">
         <Link to={Posts.getPageUrl(post)}>
           <Components.Icon name="comment" />
-          <span className="posts-commenters-comments-count">{post.commentCount}</span>
+          <span className="posts-commenters-comments-count">
+            {post.commentCount}
+          </span>
           <span className="sr-only">Comments</span>
         </Link>
       </div>
@@ -20,6 +24,6 @@ const PostsCommenters = ({post}) => {
   );
 };
 
-PostsCommenters.displayName = "PostsCommenters";
+PostsCommenters.displayName = 'PostsCommenters';
 
 registerComponent({ name: 'PostsCommenters', component: PostsCommenters });

--- a/packages/example-forum/lib/components/posts/PostsItem.jsx
+++ b/packages/example-forum/lib/components/posts/PostsItem.jsx
@@ -2,83 +2,122 @@ import { Components, registerComponent } from 'meteor/vulcan:core';
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'meteor/vulcan:i18n';
-import { Link } from 'react-router';
+import { Link } from 'react-router-dom';
 import { Posts } from '../../modules/posts/index.js';
 import moment from 'moment';
 
 class PostsItem extends PureComponent {
-
   renderCategories() {
-    return this.props.post.categories && this.props.post.categories.length > 0 ? <Components.PostsCategories post={this.props.post} /> : "";
+    return this.props.post.categories &&
+      this.props.post.categories.length > 0 ? (
+      <Components.PostsCategories post={this.props.post} />
+    ) : (
+      ''
+    );
   }
 
   renderCommenters() {
-    return this.props.post.commenters && this.props.post.commenters.length > 0 ? <Components.PostsCommenters post={this.props.post}/> : "";
+    return this.props.post.commenters &&
+      this.props.post.commenters.length > 0 ? (
+      <Components.PostsCommenters post={this.props.post} />
+    ) : (
+      ''
+    );
   }
 
   renderActions() {
     return (
       <div className="posts-actions">
-        <Components.ModalTrigger title="Edit Post" component={<a className="posts-action-edit"><FormattedMessage id="posts.edit"/></a>}>
+        <Components.ModalTrigger
+          title="Edit Post"
+          component={
+            <a className="posts-action-edit">
+              <FormattedMessage id="posts.edit" />
+            </a>
+          }
+        >
           <Components.PostsEditForm post={this.props.post} />
         </Components.ModalTrigger>
       </div>
-    )
+    );
   }
-  
+
   render() {
+    const { post } = this.props;
 
-    const {post} = this.props;
-
-    let postClass = "posts-item";
-    if (post.sticky) postClass += " posts-sticky";
+    let postClass = 'posts-item';
+    if (post.sticky) postClass += ' posts-sticky';
 
     return (
       <div className={postClass}>
-
         <div className="posts-item-vote">
-          <Components.Vote collection={Posts} document={post} currentUser={this.props.currentUser} />
+          <Components.Vote
+            collection={Posts}
+            document={post}
+            currentUser={this.props.currentUser}
+          />
         </div>
 
-        {post.thumbnailUrl ? <Components.PostsThumbnail post={post}/> : null}
+        {post.thumbnailUrl ? <Components.PostsThumbnail post={post} /> : null}
 
         <div className="posts-item-content">
-
           <h3 className="posts-item-title">
-            <Link to={Posts.getLink(post)} className="posts-item-title-link" target={Posts.getLinkTarget(post)}>
+            <Link
+              to={Posts.getLink(post)}
+              className="posts-item-title-link"
+              target={Posts.getLinkTarget(post)}
+            >
               {post.title}
             </Link>
             {this.renderCategories()}
           </h3>
 
           <div className="posts-item-meta">
-            {post.user? <div className="posts-item-user"><Components.UsersAvatar user={post.user} size="small"/><Components.UsersName user={post.user}/></div> : null}
-            <div className="posts-item-date">{post.postedAt ? moment(new Date(post.postedAt)).fromNow() : <FormattedMessage id="posts.dateNotDefined"/>}</div>
+            {post.user ? (
+              <div className="posts-item-user">
+                <Components.UsersAvatar user={post.user} size="small" />
+                <Components.UsersName user={post.user} />
+              </div>
+            ) : null}
+            <div className="posts-item-date">
+              {post.postedAt ? (
+                moment(new Date(post.postedAt)).fromNow()
+              ) : (
+                <FormattedMessage id="posts.dateNotDefined" />
+              )}
+            </div>
             <div className="posts-item-comments">
               <Link to={Posts.getPageUrl(post)}>
-                {!post.commentCount || post.commentCount === 0 ? <FormattedMessage id="comments.count_0"/> : 
-                  post.commentCount === 1 ? <FormattedMessage id="comments.count_1" /> :
-                    <FormattedMessage id="comments.count_2" values={{count: post.commentCount}}/>
-                }
+                {!post.commentCount || post.commentCount === 0 ? (
+                  <FormattedMessage id="comments.count_0" />
+                ) : post.commentCount === 1 ? (
+                  <FormattedMessage id="comments.count_1" />
+                ) : (
+                  <FormattedMessage
+                    id="comments.count_2"
+                    values={{ count: post.commentCount }}
+                  />
+                )}
               </Link>
             </div>
-            {this.props.currentUser && this.props.currentUser.isAdmin ? <Components.PostsStats post={post} /> : null}
-            {Posts.options.mutations.edit.check(this.props.currentUser, post) && this.renderActions()}
+            {this.props.currentUser && this.props.currentUser.isAdmin ? (
+              <Components.PostsStats post={post} />
+            ) : null}
+            {Posts.options.mutations.edit.check(this.props.currentUser, post) &&
+              this.renderActions()}
           </div>
-
         </div>
 
         {this.renderCommenters()}
-
       </div>
-    )
+    );
   }
 }
 
 PostsItem.propTypes = {
   currentUser: PropTypes.object,
   post: PropTypes.object.isRequired,
-  terms: PropTypes.object,
+  terms: PropTypes.object
 };
 
 registerComponent({ name: 'PostsItem', component: PostsItem });

--- a/packages/example-forum/lib/components/users/UsersAvatar.jsx
+++ b/packages/example-forum/lib/components/users/UsersAvatar.jsx
@@ -2,41 +2,51 @@ import { registerComponent } from 'meteor/vulcan:core';
 import React from 'react';
 import PropTypes from 'prop-types';
 import Users from 'meteor/vulcan:users';
-import { Link } from 'react-router';
+import { Link } from 'react-router-dom';
 import classNames from 'classnames';
 
-const UsersAvatar = ({className, user, link}) => {
-
+const UsersAvatar = ({ className, user, link }) => {
   const avatarUrl = user.avatarUrl || Users.avatar.getUrl(user);
 
-  const img = <img alt={Users.getDisplayName(user)} className="avatar-image" src={avatarUrl} title={user.username}/>;
-  const initials = <span className="avatar-initials"><span>{Users.avatar.getInitials(user)}</span></span>;
+  const img = (
+    <img
+      alt={Users.getDisplayName(user)}
+      className="avatar-image"
+      src={avatarUrl}
+      title={user.username}
+    />
+  );
+  const initials = (
+    <span className="avatar-initials">
+      <span>{Users.avatar.getInitials(user)}</span>
+    </span>
+  );
 
   const avatar = avatarUrl ? img : initials;
 
   return (
     <div className={classNames('avatar', className)}>
-      {link ? 
+      {link ? (
         <Link to={Users.getProfileUrl(user)}>
           <span>{avatar}</span>
-        </Link> 
-        : <span>{avatar}</span>
-      }
+        </Link>
+      ) : (
+        <span>{avatar}</span>
+      )}
     </div>
   );
-
-}
+};
 
 UsersAvatar.propTypes = {
   user: PropTypes.object.isRequired,
   size: PropTypes.string,
   link: PropTypes.bool
-}
+};
 
 UsersAvatar.defaultProps = {
   size: 'medium',
   link: true
-}
+};
 
 UsersAvatar.displayName = 'UsersAvatar';
 

--- a/packages/example-forum/lib/components/users/UsersName.jsx
+++ b/packages/example-forum/lib/components/users/UsersName.jsx
@@ -2,13 +2,17 @@ import { registerComponent } from 'meteor/vulcan:core';
 import React from 'react';
 import PropTypes from 'prop-types';
 import Users from 'meteor/vulcan:users';
-import { Link } from 'react-router';
+import { Link } from 'react-router-dom';
 
-const UsersName = ({user}) => <Link className="users-name" to={Users.getProfileUrl(user)}>{Users.getDisplayName(user)}</Link>
+const UsersName = ({ user }) => (
+  <Link className="users-name" to={Users.getProfileUrl(user)}>
+    {Users.getDisplayName(user)}
+  </Link>
+);
 
 UsersName.propTypes = {
-  user: PropTypes.object.isRequired,
-}
+  user: PropTypes.object.isRequired
+};
 
 UsersName.displayName = 'UsersName';
 

--- a/packages/example-forum/lib/components/users/UsersProfile.jsx
+++ b/packages/example-forum/lib/components/users/UsersProfile.jsx
@@ -1,54 +1,90 @@
-import { Components, registerComponent, withDocument, withCurrentUser } from 'meteor/vulcan:core';
+import {
+  Components,
+  registerComponent,
+  withDocument,
+  withCurrentUser
+} from 'meteor/vulcan:core';
 import React from 'react';
 import { FormattedMessage } from 'meteor/vulcan:i18n';
 import Users from 'meteor/vulcan:users';
-import { Link } from 'react-router';
+import { Link } from 'react-router-dom';
 
-const UsersProfile = (props) => {
+const UsersProfile = props => {
   if (props.loading) {
-
-    return <div className="page users-profile"><Components.Loading/></div>
-
+    return (
+      <div className="page users-profile">
+        <Components.Loading />
+      </div>
+    );
   } else if (!props.document) {
-
     // console.log(`// missing user (_id/slug: ${props.documentId || props.slug})`);
-    return <div className="page users-profile"><FormattedMessage id="app.404"/></div> 
-  
+    return (
+      <div className="page users-profile">
+        <FormattedMessage id="app.404" />
+      </div>
+    );
   } else {
-
     const user = props.document;
 
-    const terms = {view: "userPosts", userId: user._id};
+    const terms = { view: 'userPosts', userId: user._id };
 
     return (
       <div className="page users-profile">
-        <Components.HeadTags url={Users.getProfileUrl(user, true)} title={Users.getDisplayName(user)} />
+        <Components.HeadTags
+          url={Users.getProfileUrl(user, true)}
+          title={Users.getDisplayName(user)}
+        />
         <h2 className="page-title">{Users.getDisplayName(user)}</h2>
-        {user.htmlBio ? <div dangerouslySetInnerHTML={{__html: user.htmlBio}}></div> : null }
+        {user.htmlBio ? (
+          <div dangerouslySetInnerHTML={{ __html: user.htmlBio }} />
+        ) : null}
         <ul>
-          {user.twitterUsername ? <li><a href={"http://twitter.com/" + user.twitterUsername}>@{user.twitterUsername}</a></li> : null }
-          {user.website ? <li><a href={user.website}>{user.website}</a></li> : null }
-          <Components.ShowIf check={Users.options.mutations.edit.check} document={user}>
-            <li><Link to={Users.getEditUrl(user)}><FormattedMessage id="users.edit_account"/></Link></li>
+          {user.twitterUsername ? (
+            <li>
+              <a href={'http://twitter.com/' + user.twitterUsername}>
+                @{user.twitterUsername}
+              </a>
+            </li>
+          ) : null}
+          {user.website ? (
+            <li>
+              <a href={user.website}>{user.website}</a>
+            </li>
+          ) : null}
+          <Components.ShowIf
+            check={Users.options.mutations.edit.check}
+            document={user}
+          >
+            <li>
+              <Link to={Users.getEditUrl(user)}>
+                <FormattedMessage id="users.edit_account" />
+              </Link>
+            </li>
           </Components.ShowIf>
         </ul>
-        <h3><FormattedMessage id="users.posts"/></h3>
+        <h3>
+          <FormattedMessage id="users.posts" />
+        </h3>
         <Components.PostsList terms={terms} showHeader={false} />
       </div>
-    )
+    );
   }
-}
+};
 
 UsersProfile.propTypes = {
   // document: PropTypes.object.isRequired,
-}
+};
 
-UsersProfile.displayName = "UsersProfile";
+UsersProfile.displayName = 'UsersProfile';
 
 const options = {
   collection: Users,
   queryName: 'usersSingleQuery',
-  fragmentName: 'UsersProfile',
+  fragmentName: 'UsersProfile'
 };
 
-registerComponent({ name: 'UsersProfile', component: UsersProfile, hocs: [withCurrentUser, [withDocument, options]] });
+registerComponent({
+  name: 'UsersProfile',
+  component: UsersProfile,
+  hocs: [withCurrentUser, [withDocument, options]]
+});

--- a/packages/example-reactions/lib/components/Layout.jsx
+++ b/packages/example-reactions/lib/components/Layout.jsx
@@ -7,41 +7,62 @@ Wrapped with the "withList" and "withCurrentUser" containers.
 
 import React from 'react';
 import Helmet from 'react-helmet';
-import { Components, replaceComponent, registerComponent } from 'meteor/vulcan:core';
-import { Link } from 'react-router';
+import {
+  Components,
+  replaceComponent,
+  registerComponent
+} from 'meteor/vulcan:core';
+import { Link } from 'react-router-dom';
 
-const Layout = ({children, currentUser}) => 
-  
-  <div style={{maxWidth: '500px', margin: '20px auto'}}>
-
+const Layout = ({ children, currentUser }) => (
+  <div style={{ maxWidth: '500px', margin: '20px auto' }}>
     <Components.FlashMessages />
 
     <Helmet>
-      <link name="bootstrap" rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.5/css/bootstrap.min.css"/>
+      <link
+        name="bootstrap"
+        rel="stylesheet"
+        type="text/css"
+        href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.5/css/bootstrap.min.css"
+      />
     </Helmet>
 
     {/* user accounts */}
 
-    <div style={{padding: '20px 0', marginBottom: '20px', borderBottom: '1px solid #ccc'}}>
-    
+    <div
+      style={{
+        padding: '20px 0',
+        marginBottom: '20px',
+        borderBottom: '1px solid #ccc'
+      }}
+    >
       <Components.AccountsLoginForm />
-    
     </div>
 
     {/* nav */}
 
-    <div style={{padding: '20px 0', marginBottom: '20px', borderBottom: '1px solid #ccc'}}>
-    
+    <div
+      style={{
+        padding: '20px 0',
+        marginBottom: '20px',
+        borderBottom: '1px solid #ccc'
+      }}
+    >
       <ul>
-        <li><Link to="/">All Movies</Link></li>
-        <li><Link to="/my-reactions">My Reactions</Link></li>
-        <li><Link to="/my-reactions2">My Reactions (variant)</Link></li>
+        <li>
+          <Link to="/">All Movies</Link>
+        </li>
+        <li>
+          <Link to="/my-reactions">My Reactions</Link>
+        </li>
+        <li>
+          <Link to="/my-reactions2">My Reactions (variant)</Link>
+        </li>
       </ul>
-
     </div>
 
     {children}
-
   </div>
+);
 
 replaceComponent('Layout', Layout);

--- a/packages/getting-started/lib/components/other/Nav.jsx
+++ b/packages/getting-started/lib/components/other/Nav.jsx
@@ -15,7 +15,7 @@ const Nav = props => {
     <div className="nav">
       <ul>
         <li className="nav-item">
-          <NavLink activeClassName="active" to="/" onlyActiveOnIndex={true}>
+          <NavLink exact activeClassName="active" to="/">
             {sections[0]}
           </NavLink>
         </li>

--- a/packages/getting-started/lib/components/other/Nav.jsx
+++ b/packages/getting-started/lib/components/other/Nav.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { registerComponent, withCurrentUser } from 'meteor/vulcan:core';
-import { Link } from 'react-router';
+import { NavLink } from 'react-router-dom';
 
 import checks from '../../modules/checks.js';
 import withMoviesCount from '../../hocs/withMoviesCount.js';
@@ -8,28 +8,50 @@ import withQueryResolvers from '../../hocs/withQueryResolvers.js';
 import withMutationResolvers from '../../hocs/withMutationResolvers.js';
 import sections from '../../modules/sections.js';
 
-const Nav = (props) => {
-  
+const Nav = props => {
   let allChecksPassed = true;
 
   return (
     <div className="nav">
       <ul>
-        <li className="nav-item"><Link activeClassName="active" to="/" onlyActiveOnIndex={true}>{sections[0]}</Link></li>
-        <li className="nav-item"><Link activeClassName="active" to="/step/1">1. {sections[1]}</Link></li>
-          {_.range(1,20).map(i => {
-            
-              if (!checks[`step${i}`](props)) {
-                allChecksPassed = false;
-              }
-              return allChecksPassed ? 
-                <li className="nav-item" key={i}><Link activeClassName="active" to={`/step/${i+1}`}>{i+1}. {sections[i+1]}</Link></li> :
-                <li className="nav-item" key={i}>{i+1}. {sections[i+1]}</li>
-            }
-          )}
+        <li className="nav-item">
+          <NavLink activeClassName="active" to="/" onlyActiveOnIndex={true}>
+            {sections[0]}
+          </NavLink>
+        </li>
+        <li className="nav-item">
+          <NavLink activeClassName="active" to="/step/1">
+            1. {sections[1]}
+          </NavLink>
+        </li>
+        {_.range(1, 20).map(i => {
+          if (!checks[`step${i}`](props)) {
+            allChecksPassed = false;
+          }
+          return allChecksPassed ? (
+            <li className="nav-item" key={i}>
+              <NavLink activeClassName="active" to={`/step/${i + 1}`}>
+                {i + 1}. {sections[i + 1]}
+              </NavLink>
+            </li>
+          ) : (
+            <li className="nav-item" key={i}>
+              {i + 1}. {sections[i + 1]}
+            </li>
+          );
+        })}
       </ul>
     </div>
-  )
+  );
 };
 
-registerComponent({ name: 'Nav', component: Nav, hocs: [withMoviesCount, withQueryResolvers, withCurrentUser, withMutationResolvers] });
+registerComponent({
+  name: 'Nav',
+  component: Nav,
+  hocs: [
+    withMoviesCount,
+    withQueryResolvers,
+    withCurrentUser,
+    withMutationResolvers
+  ]
+});

--- a/packages/getting-started/lib/components/steps/Step.jsx
+++ b/packages/getting-started/lib/components/steps/Step.jsx
@@ -1,6 +1,10 @@
 import React from 'react';
-import { Components, registerComponent, withCurrentUser } from 'meteor/vulcan:core';
-import { Link } from 'react-router';
+import {
+  Components,
+  registerComponent,
+  withCurrentUser
+} from 'meteor/vulcan:core';
+import { Link } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
 // import SyntaxHighlighter from 'react-syntax-highlighter';
 // import { docco } from 'react-syntax-highlighter/styles/hljs';
@@ -15,14 +19,18 @@ const isCode = t => t.slice(0, 3) === '~~~';
 const languages = {
   js: 'jsx',
   gq: 'graphql',
-  sh: 'powershell',
+  sh: 'powershell'
 };
 
 // see https://github.com/rexxars/react-markdown-examples/blob/master/examples/custom-renderers/link-renderer.js
-const LinkRenderer = props => 
-  props.href.match(/^(https?:)?\/\//) ?
-    <a href={props.href} target="_blank">{props.children}</a> :
+const LinkRenderer = props =>
+  props.href.match(/^(https?:)?\/\//) ? (
+    <a href={props.href} target="_blank">
+      {props.children}
+    </a>
+  ) : (
     <Link to={props.href}>{props.children}</Link>
+  );
 
 const TextBlocks = ({ textArray, currentUser }) => (
   <div className="text-blocks">
@@ -69,7 +77,9 @@ const Step = props => {
   const textArray = Array.isArray(text) ? text : [text];
   const afterArray = Array.isArray(after) ? after : [after];
 
-  const buttonText = firstStep ? `Let's get started!` : `Move on to Step ${step + 1}`;
+  const buttonText = firstStep
+    ? 'Let\'s get started!'
+    : `Move on to Step ${step + 1}`;
 
   return (
     <div className="step">


### PR DESCRIPTION
[Vulcan core PR](https://github.com/VulcanJS/Vulcan/pull/2083)
- `IndexLink` no longer exists. Use `<NavLink exact ... >` instead
- `Link` and `NavLink` are now imported from `react-router-dom` (instead of react-router)
- Only `NavLink` tolerate styling, eg with `activeClassName` prop. `Link` are now simple `<a>` tags.
- `onlyActiveOnIndex` can be replaced by `exact`.

I tested the `getting-started`, its routing seems ok, but not the other examples. I applied the update to all packages however, so they should behave as expected. 