### PR TITLE
Fix destructure `terms` error in example-movies resolver

### DIFF
--- a/packages/example-movies/lib/modules/movies/resolvers.js
+++ b/packages/example-movies/lib/modules/movies/resolvers.js
@@ -13,7 +13,7 @@ const resolvers = {
     name: 'movies',
 
     async resolver(root, args, context) {
-      const { input: {terms = {}} } = args;
+      const { input: {terms = {}} = {terms: {}} } = args;
       let { selector, options } = await context.Movies.getParameters(terms, {}, context.currentUser);
       movies = await context.Movies.find(selector, options);
       moviesContent = movies.fetch();


### PR DESCRIPTION
Added defaults for `input` and `terms` so that the resolver does not fail when the query is sent through graphiql.