### PR TITLE
Change remaining uses of Loading to Components.Loading

### DIFF
--- a/packages/example-instagram/lib/components/comments/CommentsList.jsx
+++ b/packages/example-instagram/lib/components/comments/CommentsList.jsx
@@ -8,7 +8,7 @@ All props except currentUser are passed by the withList container.
 */
 
 import React from 'react';
-import { registerComponent, Components, withList, withCurrentUser, Loading } from 'meteor/vulcan:core';
+import { registerComponent, Components, withList, withCurrentUser } from 'meteor/vulcan:core';
 
 import Comments from '../../modules/comments/collection.js';
 
@@ -18,7 +18,7 @@ const CommentsList = ({results = [], currentUser, loading, loadMore, count, tota
 
     {loading ? 
 
-      <Loading /> :
+      <Components.Loading /> :
 
       <div className="comments-items">
         {results.map(comment => <Components.CommentsItem key={comment._id} comment={comment} currentUser={currentUser} />)}

--- a/packages/example-instagram/lib/components/pics/PicsList.jsx
+++ b/packages/example-instagram/lib/components/pics/PicsList.jsx
@@ -6,13 +6,13 @@ Wrapped with the "withList" and "withCurrentUser" containers.
 */
 
 import React from 'react';
-import { registerComponent, Components, withList, withCurrentUser, Loading } from 'meteor/vulcan:core';
+import { registerComponent, Components, withList, withCurrentUser } from 'meteor/vulcan:core';
 import Pics from '../../modules/pics/collection.js';
 
 const PicsList = ({results = [], currentUser, loading, loadMore, count, totalCount}) =>
   <div className="pics-list">
     {loading ?
-      <Loading /> :
+      <Components.Loading /> :
       <div className="pics-list-content">
         <div className="pics-list-grid">
           {results.map(pic => <Components.PicsItem key={pic._id} pic={pic} currentUser={currentUser} />)}

--- a/packages/example-interfaces/lib/components/categories/CategoriesList.jsx
+++ b/packages/example-interfaces/lib/components/categories/CategoriesList.jsx
@@ -6,7 +6,7 @@ Wrapped with the "withList" and "withCurrentUser" containers.
 */
 
 import React from 'react';
-import { registerComponent, Components, withList, withCurrentUser, Loading } from 'meteor/vulcan:core';
+import { registerComponent, Components, withList, withCurrentUser } from 'meteor/vulcan:core';
 
 import Categories from '../../modules/categories/collection.js';
 
@@ -16,7 +16,7 @@ const CategoriesList = ({results = [], terms: { parentId }, currentUser, loading
 
     {loading ? 
 
-      <Loading /> :
+      <Components.Loading /> :
 
       <div className="categories">
 

--- a/packages/example-membership/lib/components/pics/PicsList.jsx
+++ b/packages/example-membership/lib/components/pics/PicsList.jsx
@@ -6,13 +6,13 @@ Wrapped with the "withList" and "withCurrentUser" containers.
 */
 
 import React from 'react';
-import { registerComponent, Components, withList, withCurrentUser, Loading } from 'meteor/vulcan:core';
+import { registerComponent, Components, withList, withCurrentUser } from 'meteor/vulcan:core';
 import Pics from '../../modules/pics/collection.js';
 
 const PicsList = ({results = [], currentUser, loading, loadMore, count, totalCount}) => (
   <div className="pics-list">
     {loading ?
-      <Loading /> :
+      <Components.Loading /> :
       <div className="pics-list-content">
         <div className="pics-list-grid">
             {results.map(pic => <Components.PicsItem key={pic._id} pic={pic} currentUser={currentUser} />)}

--- a/packages/example-movies/lib/components/movies/MoviesList.jsx
+++ b/packages/example-movies/lib/components/movies/MoviesList.jsx
@@ -6,7 +6,7 @@ Wrapped with the "withMulti" and "withCurrentUser" containers.
 */
 
 import React from 'react';
-import { registerComponent, replaceComponent, Components, withMulti, withCurrentUser, Loading } from 'meteor/vulcan:core';
+import { registerComponent, replaceComponent, Components, withMulti, withCurrentUser } from 'meteor/vulcan:core';
 
 import Movies from '../../modules/movies/collection.js';
 
@@ -19,7 +19,7 @@ const MoviesList = ({ results = [], currentUser, loading, loadMore, count, total
     </div>
 
     {loading ? (
-      <Loading />
+      <Components.Loading />
     ) : (
       <div className="movies">
         {/* new document form */}

--- a/packages/example-permissions/lib/components/comments/CommentsList.jsx
+++ b/packages/example-permissions/lib/components/comments/CommentsList.jsx
@@ -8,7 +8,7 @@ All props except currentUser are passed by the withList container.
 */
 
 import React from 'react';
-import { registerComponent, Components, withList, withCurrentUser, Loading } from 'meteor/vulcan:core';
+import { registerComponent, Components, withList, withCurrentUser } from 'meteor/vulcan:core';
 
 import Comments from '../../modules/comments/collection.js';
 
@@ -18,7 +18,7 @@ const CommentsList = ({results = [], currentUser, loading, loadMore, count, tota
 
     {loading ? 
 
-      <Loading /> :
+      <Components.Loading /> :
 
       <div className="comments-items">
         {results.map(comment => <Components.CommentsItem key={comment._id} comment={comment} currentUser={currentUser} pic={pic} />)}

--- a/packages/example-permissions/lib/components/pics/PicsList.jsx
+++ b/packages/example-permissions/lib/components/pics/PicsList.jsx
@@ -6,14 +6,14 @@ Wrapped with the "withList" and "withCurrentUser" containers.
 */
 
 import React from 'react';
-import { registerComponent, Components, withList, withCurrentUser, Loading } from 'meteor/vulcan:core';
+import { registerComponent, Components, withList, withCurrentUser } from 'meteor/vulcan:core';
 import Pics from '../../modules/pics/collection.js';
 
 const PicsList = ({results = [], currentUser, loading, loadMore, count, totalCount}) =>
 
   <div className="pics-list">
     {loading ?
-      <Loading /> :
+      <Components.Loading /> :
       <div className="pics-list-content">
         <div className="pics-list-grid">
           {results.map(pic => <Components.PicsItem key={pic._id} pic={pic} currentUser={currentUser} />)}

--- a/packages/getting-started/lib/components/other/GraphQLSchema.jsx
+++ b/packages/getting-started/lib/components/other/GraphQLSchema.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { registerComponent, Loading, Components } from 'meteor/vulcan:core';
+import { registerComponent, Components } from 'meteor/vulcan:core';
 import SyntaxHighlighter from 'react-syntax-highlighter/prism';
 import { okaidia } from 'react-syntax-highlighter/styles/prism';
 


### PR DESCRIPTION
- Loading causes crashes in some files such as CommentsList.jsx, best to replace it with Components.Loading even where it doesn't cause crashes
- See https://vulcanjs.slack.com/archives/C4K37H9PV/p1561887684033300 and https://vulcanjs.slack.com/archives/C4K37H9PV/p1562025758035500 regarding errors
- Also, don't import Loading anymore when not needed in GraphQLSchema.jsx