### PR TITLE
Remove hardcoded head tag in template-web.browser

### DIFF
--- a/packages/_boilerplate-generator/template-web.browser.js
+++ b/packages/_boilerplate-generator/template-web.browser.js
@@ -22,8 +22,6 @@ export const headTemplate = ({
       })
     ).join('') + '>',
     
-    '<head>',
-
     dynamicHead,
 
     (headSections.length === 1)


### PR DESCRIPTION
This is done to avoid two generated opening `head` tags. The dynamicHead
passed as a paramter to the headTemplate already contains the opening
tag.

Related issue: https://github.com/VulcanJS/Vulcan/issues/2443